### PR TITLE
Read REGN chunk data

### DIFF
--- a/src/VGAudio.Cli/Metadata/Containers/Bfstm.cs
+++ b/src/VGAudio.Cli/Metadata/Containers/Bfstm.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using System.Text;
 using VGAudio.Containers;
+using VGAudio.Containers.Bxstm;
 
 namespace VGAudio.Cli.Metadata.Containers
 {
@@ -9,6 +10,33 @@ namespace VGAudio.Cli.Metadata.Containers
         public override Common ToCommon(object structure) => Bxstm.ToCommon(structure);
         public override object ReadMetadata(Stream stream) => new BfstmReader().ReadMetadata(stream);
         public override void PrintSpecificMetadata(object structure, StringBuilder builder)
-            => Bxstm.PrintSpecificMetadata(structure, builder);
+        {
+            Bxstm.PrintSpecificMetadata(structure, builder);
+
+            var bfstm = structure as BfstmStructure;
+            if (bfstm == null) throw new InvalidDataException("Could not parse file metadata.");
+
+            if (bfstm.Regn == null) return;
+
+            builder.AppendLine($"\nREGN Chunk");
+            builder.AppendLine(new string('-', 40));
+
+            for (int i = 0; i < bfstm.Regn.EntryCount; i++)
+            {
+                builder.AppendLine();
+                builder.AppendLine($"Entry {i}");
+                builder.AppendLine(new string('-', 25));
+                builder.AppendLine($"Start sample: {bfstm.Regn.Entries[i].StartSample}");
+                builder.AppendLine($"End sample: {bfstm.Regn.Entries[i].EndSample}");
+
+                for (int c = 0; c < bfstm.ChannelCount; c++)
+                {
+                    short v1 = bfstm.Regn.Entries[i].Channels[c].Value1;
+                    short v2 = bfstm.Regn.Entries[i].Channels[c].Value2;
+
+                    builder.AppendLine($"Channel {c}: {v1}, {v2}");
+                }
+            }
+        }
     }
 }

--- a/src/VGAudio/Containers/Bxstm/BCFstmStructure.cs
+++ b/src/VGAudio/Containers/Bxstm/BCFstmStructure.cs
@@ -80,15 +80,31 @@
         public int SeekChunkSize { get; set; }
 
         /// <summary>
+        /// The size of the REGN chunk as stated in the
+        /// REGN chunk header.
+        /// </summary>
+        public int RegnChunkSize { get; set; }
+
+        /// <summary>
         /// The size of the DATA chunk as stated in the
         /// DATA chunk header.
         /// </summary>
         public int DataChunkSize { get; set; }
 
         /// <summary>
+        /// The REGN chunk.
+        /// </summary>
+        public RegnChunk Regn { get; set; }
+
+        /// <summary>
         /// The audio codec.
         /// </summary>
         public BxstmCodec Codec { get; set; }
+
+        /// <summary>
+        /// The number of audio sections in the file.
+        /// </summary>
+        public int SectionCount { get; set; }
 
         /// <summary>
         /// Specifies whether the file includes an extra chunk in the header

--- a/src/VGAudio/Containers/Bxstm/RegnChunk.cs
+++ b/src/VGAudio/Containers/Bxstm/RegnChunk.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.Generic;
+
+namespace VGAudio.Containers.Bxstm
+{
+    public class RegnChunk
+    {
+        public int Size { get; set; }
+        public int EntryCount { get; set; }
+        public List<RegnEntry> Entries { get; set; } = new List<RegnEntry>();
+    }
+
+    public class RegnEntry
+    {
+        public int StartSample { get; set; }
+        public int EndSample { get; set; }
+        public List<RegnChannel> Channels { get; set; } = new List<RegnChannel>();
+    }
+
+    public class RegnChannel
+    {
+        public short PredScale { get; set; }
+        public short Value1 { get; set; }
+        public short Value2 { get; set; }
+    }
+}


### PR DESCRIPTION
This will read the REGN chunk data from BFSTM files. I've only seen this chunk on BFSTM files, but it should theoretically work on BCSTM files as well.

There are two unknown fields in the REGN chunk. Interestingly enough, the set of values that are found in these fields, and OEIS sequence A029750 through 4096 are equal.