### PR TITLE
Add 16-bit PCM BRSTM support

### DIFF
--- a/docs/templates/brstm.bt
+++ b/docs/templates/brstm.bt
@@ -1,0 +1,294 @@
+//------------------------------------------------
+//--- 010 Editor v7.0.2 Binary Template
+//
+//      File: brstm.bt
+//   Authors: Alex Barney
+//   Version: 1.0
+//   Purpose: Parse BRSTM audio files
+//   Category: Audio
+//   File Mask: *.brstm
+//   ID Bytes: 52 53 54 4D //RSTM
+//   History: 
+//   1.0   Initial Release
+//------------------------------------------------
+
+//Change this variable to display info
+//on each ADPCM frame
+const int detailedData = 0;
+
+typedef char ID[4];
+struct RSTMHeader
+{
+    local int base = FTell();
+    ID RstmId;
+    int16 BOM;
+    byte MajorVersion;
+    byte MinorVersion;
+    int32 FileSize;
+    int16 HeaderSize;
+    int16 ChunkCount;
+    int32 HeadChunkOffset;
+    int32 HeadChunkSize;
+    int32 AdpcChunkOffset;
+    int32 AdpcChunkSize;
+    int32 DataChunkOffset;
+    int32 DataChunkSize;
+    //byte Padding[HeaderSize - FTell() - base];
+};
+
+enum <byte> AudioCodec
+{
+    PCM_8Bit   = 0,
+    PCM_16Bit  = 1,
+    GcAdpcm    = 2
+};
+
+enum <byte> TrackType
+{
+    Short = 0,
+    Long  = 1
+};
+
+struct TrackOffset
+{
+    byte Marker;
+    TrackType Type;
+    int16 Padding;
+    int32 Offset;
+};
+
+struct Track(TrackType type)
+{
+    if (type == Long)
+    {
+        byte Volume;
+        byte Padding;
+        int16 Unknown1;
+        int32 Unknown2;   
+    } 
+    byte ChannelCount;
+    byte LeftChannelId;
+    byte RightChannelId;
+    byte Padding;
+};
+
+struct ChannelOffset
+{
+    int32 Marker <format=hex>;
+    int32 Offset;
+};
+
+struct AdpcmChannel (int32 base)
+{
+    int32 Marker <format=hex>;
+    int32 Offset;
+    FSeek(base + Offset);
+    SetBackColor(cSilver);
+    uint16 Coefficients[16];
+    SetBackColor(cAqua);
+    int16 Gain;
+    int16 InitialPredictorScale <format=hex>;
+    int16 History1;
+    int16 History2;
+    int16 LoopPredictorScale <format=hex>;
+    int16 LoopHistory1;
+    int16 LoopHistory2;
+};
+
+struct PcmChannel
+{
+    int32 Marker <format=hex>;
+    int32 Padding;
+};
+
+struct HEADChunk1
+{
+    AudioCodec Codec;
+    byte Loops;
+    byte ChannelCount;
+    byte Padding;
+    uint16 SampleRate;
+    uint16 Padding;
+    int32 LoopStart;
+    int32 SampleCount;
+    int32 AudioDataOffset;
+    int32 BlockCount;
+    int32 BlockSizeBytes;
+    int32 BlockSizeSamples;
+    int32 FinalBlockSizeBytesWithoutPadding;
+    int32 FinalBlockSizeSamples;
+    int32 FinalBlockSizeBytesWithPadding;
+    int32 SamplesPerSeekTableEntry;
+    int32 BytesPerSeekTableEntry;
+};
+
+struct HEADChunk2 (int32 base)
+{
+    byte TrackCount;
+    TrackType Type;
+    int16 Padding;
+    local int i;
+    for( i = 0; i < TrackCount; i++ )
+    {
+        TrackOffset Offsets;
+    }
+    for( i = 0; i < TrackCount; i++ )
+    {
+        FSeek(base + Offsets[i].Offset);
+        Track track(Offsets[i].Type);
+    }
+};
+
+struct HEADChunk3 (int32 base, AudioCodec codec)
+{
+    byte ChannelCount;
+    byte Padding[3];
+    local int i;
+    for( i = 0; i < ChannelCount; i++ )
+    {
+        ChannelOffset Offsets;
+    }
+    for( i = 0; i < ChannelCount; i++ )
+    {
+        FSeek(base + Offsets[i].Offset);
+        if (codec == GcAdpcm)
+        {
+            AdpcmChannel Channel(base);
+        }
+        else if (codec == PCM_16Bit)
+        {
+            PcmChannel Channel;
+        }
+    }
+};
+
+struct HEADChunk
+{    
+    ID HeadId;
+    int32 Size;
+    local int32 base = FTell();
+    int32 Marker1 <format=hex>;
+    int32 Chunk1Offset;
+    int32 Marker2 <format=hex>;
+    int32 Chunk2Offset;
+    int32 Marker3 <format=hex>;
+    int32 Chunk3Offset;
+    
+    SetBackColor(cLtBlue);
+    FSeek(base + Chunk1Offset);
+    HEADChunk1 Chunk1;
+
+    SetBackColor(cLtGreen);
+    FSeek(base + Chunk2Offset);
+    HEADChunk2 Chunk2(base);
+
+    SetBackColor(cAqua);
+    FSeek(base + Chunk3Offset);
+    HEADChunk3 Chunk3(base, Chunk1.Codec);
+};
+
+struct SeekTableEntryChannel
+{
+    int16 History1;
+    int16 History2;
+};
+
+struct SeekTableEntry (int32 channelCount)
+{
+    local int32 i;
+    for( i = 0; i < channelCount; i++ )
+    {
+        SeekTableEntryChannel Channel;
+    }
+};
+
+struct ADPCChunk (int32 channelCount)
+{    
+    local int32 entrySize = channelCount * 4; 
+    ID AdpcId;
+    int32 Size;
+    local int32 entryCount = Size / entrySize; 
+    local int32 i;
+    for( i = 0; i < entryCount; i++ )
+    {
+        SeekTableEntry Entry(channelCount);
+    }
+};
+
+typedef struct
+{
+    byte Predictor : 4;
+    byte Scale : 4;
+    for( i = 0; i < 14; i++ )
+    {
+        byte sample : 4;
+    }
+} AdpcmFrame <size=8> ;
+
+struct Block(int32 size, AudioCodec codec)
+{
+    if (codec == GcAdpcm && detailedData)
+    {
+        local int32 frameCount = size / 8;
+        local int32 j;
+        for( j = 0; j < frameCount; j++ )
+        {
+            AdpcmFrame Frame;
+        }
+    }
+    else
+    {
+        byte Audio[size];
+    }
+};
+
+struct Channel(int32 num, HEADChunk1 &head)
+{
+    local int32 fullBlocks = head.BlockCount - 1;
+    FSeek(head.AudioDataOffset + head.BlockSizeBytes * num);
+
+    local int32 i;
+    for (i = 0; i < fullBlocks; i++)
+    {
+        FSeek(head.AudioDataOffset + (i * head.BlockSizeBytes * head.ChannelCount) + head.BlockSizeBytes * num);
+        Block block(head.BlockSizeBytes, head.Codec);
+    }
+    
+    FSeek(head.AudioDataOffset + (fullBlocks * head.BlockSizeBytes * head.ChannelCount) + head.FinalBlockSizeBytesWithPadding * num);
+    Block block(head.FinalBlockSizeBytesWithoutPadding, head.Codec);
+};
+
+struct DATAChunk (HEADChunk1 &head)
+{    
+    ID DataId;
+    int32 Size;
+    int32 PaddingSize;
+    byte Padding[PaddingSize - 4];
+    SetBackColor(cNone);
+    FSeek(head.AudioDataOffset);
+
+    local int32 i;
+    for (i = 0; i < head.ChannelCount; i++)
+    {
+        Channel Channels(i, head);        
+    }
+};
+
+BigEndian();
+SetBackColor(cLtGray);
+RSTMHeader Rstm;
+
+SetBackColor(cSilver);
+FSeek(Rstm.HeadChunkOffset);
+HEADChunk Head;
+
+if (Rstm.AdpcChunkOffset != 0)
+{
+    SetBackColor(cLtRed);
+    FSeek(Rstm.AdpcChunkOffset);
+    ADPCChunk Adpc(Head.Chunk1.ChannelCount);
+}
+
+SetBackColor(cLtGray);
+FSeek(Rstm.DataChunkOffset);
+DATAChunk Data(Head.Chunk1);

--- a/src/VGAudio.Benchmark/GenerateAudio.cs
+++ b/src/VGAudio.Benchmark/GenerateAudio.cs
@@ -39,7 +39,7 @@ namespace VGAudio.Benchmark
                 channels[i] = GenerateSineWave(sampleCount, frequencies[i], sampleRate);
             }
 
-            return new Pcm16Format(sampleCount, sampleRate, channels);
+            return new Pcm16Format(channels, sampleRate);
         }
 
         public static GcAdpcmFormat GenerateAdpcmSineWave(int sampleCount, int channelCount, int sampleRate)
@@ -59,7 +59,7 @@ namespace VGAudio.Benchmark
                 channels[i] = builder.Build();
             }
 
-            var adpcm = new GcAdpcmFormat(sampleCount, sampleRate, channels);
+            var adpcm = new GcAdpcmFormat(channels, sampleRate);
 
             return adpcm;
         }

--- a/src/VGAudio.Cli/AudioFormat.cs
+++ b/src/VGAudio.Cli/AudioFormat.cs
@@ -2,6 +2,7 @@
 {
     internal enum AudioFormat
     {
+        None,
         Pcm16,
         Pcm8,
         GcAdpcm

--- a/src/VGAudio.Cli/CliArguments.cs
+++ b/src/VGAudio.Cli/CliArguments.cs
@@ -91,6 +91,27 @@ namespace VGAudio.Cli
 
                             options.NoLoop = true;
                             continue;
+                        case "F":
+                            if (options.OutFormat != AudioFormat.None)
+                            {
+                                PrintWithUsage("Can't set multiple formats.");
+                                return null;
+                            }
+                            if (i + 1 >= args.Length)
+                            {
+                                PrintWithUsage("No argument after -f switch.");
+                                return null;
+                            }
+                            var format = GetFormat(args[i + 1]);
+                            if (format == AudioFormat.None)
+                            {
+                                PrintWithUsage("Format must be one of pcm16, pcm8, or GcAdpcm");
+                                return null;
+                            }
+
+                            options.OutFormat = format;
+                            i++;
+                            continue;
                         case "-HELP":
                         case "H":
                             PrintUsage();
@@ -201,6 +222,17 @@ namespace VGAudio.Cli
             }
 
             return range;
+        }
+
+        private static AudioFormat GetFormat(string format)
+        {
+            switch (format.ToLower())
+            {
+                case "pcm16": return AudioFormat.Pcm16;
+                case "pcm8": return AudioFormat.Pcm8;
+                case "gcadpcm": return AudioFormat.GcAdpcm;
+                default: return AudioFormat.None;
+            }
         }
 
         private static void PrintWithUsage(string toPrint)

--- a/src/VGAudio.Cli/CliArguments.cs
+++ b/src/VGAudio.Cli/CliArguments.cs
@@ -251,6 +251,7 @@ namespace VGAudio.Cli
             Console.WriteLine("  -l <start-end> Set the start and end loop points");
             Console.WriteLine("                 Loop points are given in zero-based samples");
             Console.WriteLine("      --no-loop  Sets the audio to not loop");
+            Console.WriteLine("  -f             Specify the audio format to use in the output file");
             Console.WriteLine("  -h, --help     Display this help and exit");
             Console.WriteLine("      --version  Display version information and exit");
         }

--- a/src/VGAudio.Cli/ContainerTypes.cs
+++ b/src/VGAudio.Cli/ContainerTypes.cs
@@ -9,31 +9,33 @@ namespace VGAudio.Cli
     {
         public static readonly Dictionary<FileType, ContainerType> Containers = new Dictionary<FileType, ContainerType>
         {
-            [FileType.Wave] = new ContainerType(new[] { "wav", "wave" }, () => new WaveReader(), () => new WaveWriter()),
-            [FileType.Dsp] = new ContainerType(new[] { "dsp" }, () => new DspReader(), () => new DspWriter()),
-            [FileType.Idsp] = new ContainerType(new[] { "idsp" }, () => new IdspReader(), () => new IdspWriter()),
-            [FileType.Brstm] = new ContainerType(new[] { "brstm" }, () => new BrstmReader(), () => new BrstmWriter()),
-            [FileType.Bcstm] = new ContainerType(new[] { "bcstm" }, () => new BcstmReader(), () => new BcstmWriter()),
-            [FileType.Bfstm] = new ContainerType(new[] { "bfstm" }, () => new BfstmReader(), () => new BfstmWriter()),
-            [FileType.Genh] = new ContainerType(new[] { "genh" }, () => new GenhReader(), null)
+            [FileType.Wave] = new ContainerType(new[] { "wav", "wave" }, () => new WaveReader(), () => new WaveWriter(), CreateConfiguration.Wave),
+            [FileType.Dsp] = new ContainerType(new[] { "dsp" }, () => new DspReader(), () => new DspWriter(), CreateConfiguration.Dsp),
+            [FileType.Idsp] = new ContainerType(new[] { "idsp" }, () => new IdspReader(), () => new IdspWriter(), CreateConfiguration.Idsp),
+            [FileType.Brstm] = new ContainerType(new[] { "brstm" }, () => new BrstmReader(), () => new BrstmWriter(), CreateConfiguration.Brstm),
+            [FileType.Bcstm] = new ContainerType(new[] { "bcstm" }, () => new BcstmReader(), () => new BcstmWriter(), CreateConfiguration.Bcstm),
+            [FileType.Bfstm] = new ContainerType(new[] { "bfstm" }, () => new BfstmReader(), () => new BfstmWriter(), CreateConfiguration.Bfstm),
+            [FileType.Genh] = new ContainerType(new[] { "genh" }, () => new GenhReader(), null, null)
         };
 
         public static readonly Dictionary<string, FileType> Extensions =
-            Containers.SelectMany(x => x.Value.Names.Select(y => new {y, x.Key}))
+            Containers.SelectMany(x => x.Value.Names.Select(y => new { y, x.Key }))
             .ToDictionary(x => x.y, x => x.Key);
     }
 
     internal class ContainerType
     {
-        public ContainerType(IEnumerable<string> names, Func<IAudioReader> getReader, Func<IAudioWriter> getWriter)
+        public ContainerType(IEnumerable<string> names, Func<IAudioReader> getReader, Func<IAudioWriter> getWriter, Func<Options, IConfiguration> getConfiguration)
         {
             Names = names;
             GetReader = getReader;
             GetWriter = getWriter;
+            GetConfiguration = getConfiguration;
         }
 
         public IEnumerable<string> Names { get; }
         public Func<IAudioReader> GetReader { get; }
         public Func<IAudioWriter> GetWriter { get; }
+        public Func<Options, IConfiguration> GetConfiguration { get; }
     }
 }

--- a/src/VGAudio.Cli/Converter.cs
+++ b/src/VGAudio.Cli/Converter.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.IO;
 using VGAudio.Cli.Metadata;
 
 namespace VGAudio.Cli
@@ -14,18 +15,25 @@ namespace VGAudio.Cli
 
             if (options.Job == JobType.Convert)
             {
-                Stopwatch watch = Stopwatch.StartNew();
-                bool success = Convert.ConvertFile(options);
-                watch.Stop();
+                try
+                {
+                    Stopwatch watch = Stopwatch.StartNew();
+                    bool success = Convert.ConvertFile(options);
+                    watch.Stop();
 
-                if (success)
-                {
-                    Console.WriteLine("Success!");
-                    Console.WriteLine($"Time elapsed: {watch.Elapsed.TotalSeconds}");
+                    if (success)
+                    {
+                        Console.WriteLine("Success!");
+                        Console.WriteLine($"Time elapsed: {watch.Elapsed.TotalSeconds}");
+                    }
+                    else
+                    {
+                        return false;
+                    }
                 }
-                else
+                catch (InvalidDataException ex)
                 {
-                    return false;
+                    Console.WriteLine(ex.Message);
                 }
             }
 

--- a/src/VGAudio.Cli/CreateConfiguration.cs
+++ b/src/VGAudio.Cli/CreateConfiguration.cs
@@ -1,0 +1,107 @@
+﻿using System.IO;
+using VGAudio.Containers;
+using VGAudio.Containers.Bxstm;
+using VGAudio.Containers.Dsp;
+using VGAudio.Containers.Wave;
+
+namespace VGAudio.Cli
+{
+    internal static class CreateConfiguration
+    {
+        public static IConfiguration Wave(Options options)
+        {
+            var config = new WaveConfiguration();
+
+            switch (options.OutFormat)
+            {
+                case AudioFormat.GcAdpcm:
+                    throw new InvalidDataException("Can't use format GcAdpcm with Wave files");
+                case AudioFormat.Pcm16:
+                    break;
+                case AudioFormat.Pcm8:
+                    throw new InvalidDataException("Can't use format PCM8 with Wave files");
+            }
+
+            return config;
+        }
+
+        public static IConfiguration Dsp(Options options)
+        {
+            var config = new DspConfiguration();
+
+            switch (options.OutFormat)
+            {
+                case AudioFormat.Pcm16:
+                    throw new InvalidDataException("Can't use format PCM16 with DSP files");
+                case AudioFormat.Pcm8:
+                    throw new InvalidDataException("Can't use format PCM8 with DSP files");
+            }
+
+            return config;
+        }
+
+        public static IConfiguration Idsp(Options options)
+        {
+            var config = new DspConfiguration();
+
+            switch (options.OutFormat)
+            {
+                case AudioFormat.Pcm16:
+                    throw new InvalidDataException("Can't use format PCM16 with IDSP files");
+                case AudioFormat.Pcm8:
+                    throw new InvalidDataException("Can't use format PCM8 with IDSP files");
+            }
+
+            return config;
+        }
+
+        public static IConfiguration Brstm(Options options)
+        {
+            var config = new BrstmConfiguration();
+
+            switch (options.OutFormat)
+            {
+                case AudioFormat.GcAdpcm:
+                    config.Codec = BxstmCodec.Adpcm;
+                    break;
+                case AudioFormat.Pcm16:
+                    config.Codec = BxstmCodec.Pcm16Bit;
+                    break;
+                case AudioFormat.Pcm8:
+                    throw new InvalidDataException("Can't use format PCM8 with BRSTM files");
+            }
+
+            return config;
+        }
+
+        public static IConfiguration Bcstm(Options options)
+        {
+            var config = new DspConfiguration();
+
+            switch (options.OutFormat)
+            {
+                case AudioFormat.Pcm16:
+                    throw new InvalidDataException("Can't use format PCM16 with BCSTM files");
+                case AudioFormat.Pcm8:
+                    throw new InvalidDataException("Can't use format PCM8 with BCSTM files");
+            }
+
+            return config;
+        }
+
+        public static IConfiguration Bfstm(Options options)
+        {
+            var config = new DspConfiguration();
+
+            switch (options.OutFormat)
+            {
+                case AudioFormat.Pcm16:
+                    throw new InvalidDataException("Can't use format PCM16 with BFSTM files");
+                case AudioFormat.Pcm8:
+                    throw new InvalidDataException("Can't use format PCM8 with BFSTM files");
+            }
+
+            return config;
+        }
+    }
+}

--- a/src/VGAudio.Cli/Metadata/Common.cs
+++ b/src/VGAudio.Cli/Metadata/Common.cs
@@ -1,4 +1,7 @@
-﻿namespace VGAudio.Cli.Metadata
+﻿using System;
+using VGAudio.Containers.Bxstm;
+
+namespace VGAudio.Cli.Metadata
 {
     internal class Common
     {
@@ -9,5 +12,20 @@
         public int LoopStart { get; set; }
         public int LoopEnd { get; set; }
         public AudioFormat Format { get; set; }
+
+        public static AudioFormat FromBxstm(BxstmCodec codec)
+        {
+            switch (codec)
+            {
+                case BxstmCodec.Pcm8Bit:
+                    return AudioFormat.Pcm8;
+                case BxstmCodec.Pcm16Bit:
+                    return AudioFormat.Pcm16;
+                case BxstmCodec.Adpcm:
+                    return AudioFormat.GcAdpcm;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(codec), codec, null);
+            }
+        }
     }
 }

--- a/src/VGAudio.Cli/Metadata/Containers/Bxstm.cs
+++ b/src/VGAudio.Cli/Metadata/Containers/Bxstm.cs
@@ -18,7 +18,7 @@ namespace VGAudio.Cli.Metadata.Containers
                 SampleCount = bxstm.SampleCount,
                 SampleRate = bxstm.SampleRate,
                 ChannelCount = bxstm.ChannelCount,
-                Format = AudioFormat.GcAdpcm,
+                Format = Common.FromBxstm(bxstm.Codec),
                 Looping = bxstm.Looping,
                 LoopStart = bxstm.LoopStart,
                 LoopEnd = bxstm.SampleCount
@@ -54,6 +54,7 @@ namespace VGAudio.Cli.Metadata.Containers
                 PrintTrackMetadata(bxstm.Tracks[i], builder);
             }
 
+            if (bxstm.Codec != BxstmCodec.Adpcm) return;
             GcAdpcm.PrintAdpcmMetadata(bxstm.Channels.Cast<GcAdpcmChannelInfo>().ToList(), builder);
         }
 

--- a/src/VGAudio.Cli/Metadata/Containers/Bxstm.cs
+++ b/src/VGAudio.Cli/Metadata/Containers/Bxstm.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Text;
 using VGAudio.Containers.Bxstm;
+using VGAudio.Formats;
 using VGAudio.Formats.GcAdpcm;
 
 namespace VGAudio.Cli.Metadata.Containers
@@ -58,7 +59,7 @@ namespace VGAudio.Cli.Metadata.Containers
             GcAdpcm.PrintAdpcmMetadata(bxstm.Channels.Cast<GcAdpcmChannelInfo>().ToList(), builder);
         }
 
-        public static void PrintTrackMetadata(GcAdpcmTrack track, StringBuilder builder)
+        public static void PrintTrackMetadata(AudioTrack track, StringBuilder builder)
         {
             builder.AppendLine($"Channel Count: {track.ChannelCount}");
             builder.AppendLine($"Left channel ID: {track.ChannelLeft}");

--- a/src/VGAudio.Cli/Metadata/Containers/GcAdpcm.cs
+++ b/src/VGAudio.Cli/Metadata/Containers/GcAdpcm.cs
@@ -32,7 +32,7 @@ namespace VGAudio.Cli.Metadata.Containers
 
         public static string CoefficientsToString(short[] coefs)
         {
-            if (coefs.Length < 14) return "";
+            if (coefs == null || coefs.Length < 14) return "";
 
             var coefOut = new StringBuilder();
 

--- a/src/VGAudio.Cli/Options.cs
+++ b/src/VGAudio.Cli/Options.cs
@@ -16,6 +16,7 @@ namespace VGAudio.Cli
         public bool NoLoop { get; set; }
         public int LoopStart { get; set; }
         public int LoopEnd { get; set; }
+        public AudioFormat OutFormat { get; set; }
     }
 
     internal class AudioFile

--- a/src/VGAudio.Tests/Containers/BrstmTests.cs
+++ b/src/VGAudio.Tests/Containers/BrstmTests.cs
@@ -1,4 +1,5 @@
 ﻿using VGAudio.Containers;
+using VGAudio.Containers.Bxstm;
 using VGAudio.Formats;
 using Xunit;
 
@@ -15,6 +16,18 @@ namespace VGAudio.Tests.Containers
             GcAdpcmFormat audio = GenerateAudio.GenerateAdpcmSineWave(BuildParseTestOptions.Samples, numChannels, BuildParseTestOptions.SampleRate);
 
             BuildParseTests.BuildParseCompareAudio(audio, new BrstmWriter(), new BrstmReader());
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(8)]
+        public void BrstmBuildAndParseEqualPcm(int numChannels)
+        {
+            Pcm16Format audio = GenerateAudio.GeneratePcmSineWave(BuildParseTestOptions.Samples, numChannels, BuildParseTestOptions.SampleRate);
+            var writer = new BrstmWriter {Configuration = {Codec = BxstmCodec.Pcm16Bit}};
+
+            BuildParseTests.BuildParseCompareAudio(audio, writer, new BrstmReader());
         }
     }
 }

--- a/src/VGAudio.Tests/Equality/AudioTrackComparer.cs
+++ b/src/VGAudio.Tests/Equality/AudioTrackComparer.cs
@@ -1,11 +1,11 @@
 ﻿using System.Collections.Generic;
-using VGAudio.Formats.GcAdpcm;
+using VGAudio.Formats;
 
 namespace VGAudio.Tests.Equality
 {
-    public sealed class GcAdpcmTrackComparer : EqualityComparer<GcAdpcmTrack>
+    public sealed class AudioTrackComparer : EqualityComparer<AudioTrack>
     {
-        public override bool Equals(GcAdpcmTrack x, GcAdpcmTrack y)
+        public override bool Equals(AudioTrack x, AudioTrack y)
         {
             if (ReferenceEquals(x, y)) return true;
             if (ReferenceEquals(x, null)) return false;
@@ -19,7 +19,7 @@ namespace VGAudio.Tests.Equality
                 x.Volume == y.Volume;
         }
 
-        public override int GetHashCode(GcAdpcmTrack obj)
+        public override int GetHashCode(AudioTrack obj)
         {
             unchecked
             {

--- a/src/VGAudio.Tests/Equality/GcAdpcmFormatComparer.cs
+++ b/src/VGAudio.Tests/Equality/GcAdpcmFormatComparer.cs
@@ -18,9 +18,8 @@ namespace VGAudio.Tests.Equality
                 x.LoopStart == y.LoopStart &&
                 x.LoopEnd == y.LoopEnd &&
                 x.Looping == y.Looping &&
-                x.Tracks.SequenceEqual(y.Tracks, new GcAdpcmTrackComparer()) &&
+                (x.Tracks ?? new List<AudioTrack>()).SequenceEqual(y.Tracks ?? new List<AudioTrack>(), new AudioTrackComparer()) &&
                 x.Channels.SequenceEqual(y.Channels, new GcAdpcmChannelComparer());
-
         }
 
         public override int GetHashCode(GcAdpcmFormat obj)

--- a/src/VGAudio.Tests/Formats/GcAdpcmFormatBuilderTests.cs
+++ b/src/VGAudio.Tests/Formats/GcAdpcmFormatBuilderTests.cs
@@ -21,7 +21,7 @@ namespace VGAudio.Tests.Formats
         public void TracksAreSetAfterCreation()
         {
             GcAdpcmChannel[] channels = GenerateAudio.GenerateAdpcmChannelsEmpty(100, 2);
-            var tracks = new List<GcAdpcmTrack> { new GcAdpcmTrack(1, 0, 0), new GcAdpcmTrack(1, 1, 0) };
+            var tracks = new List<AudioTrack> { new AudioTrack(1, 0, 0), new AudioTrack(1, 1, 0) };
             GcAdpcmFormat adpcm = GcAdpcmFormat.GetBuilder(channels, 32000).WithTracks(tracks).Build();
             Assert.Equal(tracks, adpcm.Tracks);
         }

--- a/src/VGAudio.Tests/Formats/GcAdpcmFormatTests.cs
+++ b/src/VGAudio.Tests/Formats/GcAdpcmFormatTests.cs
@@ -43,8 +43,8 @@ namespace VGAudio.Tests.Formats
         {
             GcAdpcmChannel[] channels = GenerateAudio.GenerateAdpcmSineWave(100, 2, 48000).Channels;
 
-            GcAdpcmFormat adpcm = new GcAdpcmFormat(100, 48000, new[] { channels[0] });
-            GcAdpcmFormat adpcm2 = new GcAdpcmFormat(100, 48000, new[] { channels[1] });
+            GcAdpcmFormat adpcm = new GcAdpcmFormat(new[] { channels[0] }, 48000);
+            GcAdpcmFormat adpcm2 = new GcAdpcmFormat(new[] { channels[1] }, 48000);
             GcAdpcmFormat combined = adpcm.Add(adpcm2);
 
             Assert.Equal(adpcm.Channels[0], combined.Channels[0], new GcAdpcmChannelComparer());
@@ -56,8 +56,8 @@ namespace VGAudio.Tests.Formats
         {
             GcAdpcmChannel[] channels = GenerateAudio.GenerateAdpcmSineWave(100, 2, 48000).Channels;
             GcAdpcmChannel[] channels2 = GenerateAudio.GenerateAdpcmSineWave(200, 2, 48000).Channels;
-            GcAdpcmFormat adpcm = new GcAdpcmFormat(100, 48000, new[] { channels[0] });
-            GcAdpcmFormat adpcm2 = new GcAdpcmFormat(200, 48000, new[] { channels2[1] });
+            GcAdpcmFormat adpcm = new GcAdpcmFormat(new[] { channels[0] }, 48000);
+            GcAdpcmFormat adpcm2 = new GcAdpcmFormat(new[] { channels2[1] }, 48000);
 
             Exception ex = Record.Exception(() => adpcm.Add(adpcm2));
             Assert.IsType<ArgumentException>(ex);

--- a/src/VGAudio.Tests/GenerateAudio.cs
+++ b/src/VGAudio.Tests/GenerateAudio.cs
@@ -43,7 +43,7 @@ namespace VGAudio.Tests
         public static Pcm16Format GeneratePcmSineWave(int sampleCount, int channelCount, int sampleRate)
         {
             short[][] channels = GeneratePcmSineWaveChannels(sampleCount, channelCount, sampleRate);
-            return new Pcm16Format(sampleCount, sampleRate, channels);
+            return new Pcm16Format(channels, sampleRate);
         }
 
         public static GcAdpcmFormat GenerateAdpcmSineWave(int sampleCount, int channelCount, int sampleRate)
@@ -64,7 +64,7 @@ namespace VGAudio.Tests
                         .Build();
             }
 
-            var adpcm = new GcAdpcmFormat(sampleCount, sampleRate, channels);
+            var adpcm = new GcAdpcmFormat(channels, sampleRate);
 
             return adpcm;
         }

--- a/src/VGAudio.Uwp/ViewModels/MainViewModel.cs
+++ b/src/VGAudio.Uwp/ViewModels/MainViewModel.cs
@@ -34,6 +34,12 @@ namespace VGAudio.Uwp.ViewModels
             set => SelectedFileType = (FileType)value;
         }
 
+        public Dictionary<BxstmCodec, string> FormatTypesBinding { get; } = new Dictionary<BxstmCodec, string>
+        {
+            [BxstmCodec.Adpcm] = "DSP-ADPCM",
+            [BxstmCodec.Pcm16Bit] = "16-bit PCM"
+        };
+
         public FileType SelectedFileType { get; set; } = FileType.Dsp;
 
         public bool StateNotOpened => State == MainState.NotOpened;

--- a/src/VGAudio.Uwp/Views/Brstm.xaml
+++ b/src/VGAudio.Uwp/Views/Brstm.xaml
@@ -17,6 +17,10 @@
             <local:SeekTableTypeEnumToBoolConverter x:Key="SeekTableTypeConverter" />
         </Grid.Resources>
         <StackPanel>
+            <StackPanel Margin="0,5,0,0" Orientation="Horizontal">
+                <TextBlock Text="Audio format:" TextWrapping="Wrap" VerticalAlignment="Center"/>
+                <ComboBox  Margin="10, 0" ItemsSource="{Binding Path=FormatTypesBinding, Mode=OneTime}" DisplayMemberPath="Value" SelectedValuePath="Key" SelectedValue="{Binding BrstmConfiguration.Codec, Mode=TwoWay}"/>
+            </StackPanel>
             <ToggleButton x:Name="Advanced" Margin="0,10,0,0">
                 <TextBlock Text="Show Advanced Options"/>
             </ToggleButton>

--- a/src/VGAudio/Containers/AudioWriter.cs
+++ b/src/VGAudio/Containers/AudioWriter.cs
@@ -15,7 +15,7 @@ namespace VGAudio.Containers
         public void WriteToStream(AudioData audio, Stream stream, IConfiguration configuration = null) => WriteStream(audio, stream, configuration as TConfig);
         
         protected AudioData AudioStream { get; set; }
-        protected TConfig Configuration { get; set; } = new TConfig();
+        public TConfig Configuration { get; set; } = new TConfig();
         protected abstract int FileSize { get; }
 
         protected abstract void SetupWriter(AudioData audio);

--- a/src/VGAudio/Containers/BrstmReader.cs
+++ b/src/VGAudio/Containers/BrstmReader.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.IO;
+﻿using System.IO;
 using System.Linq;
 using System.Text;
 using VGAudio.Containers.Bxstm;
@@ -41,6 +40,15 @@ namespace VGAudio.Containers
 
         protected override IAudioFormat ToAudioStream(BrstmStructure structure)
         {
+            if (structure.Codec == BxstmCodec.Adpcm)
+            {
+                return ToAdpcmStream(structure);
+            }
+            return ToPcm16Stream(structure);
+        }
+
+        private static GcAdpcmFormat ToAdpcmStream(BrstmStructure structure)
+        {
             var channels = new GcAdpcmChannel[structure.ChannelCount];
 
             for (int c = 0; c < channels.Length; c++)
@@ -69,15 +77,23 @@ namespace VGAudio.Containers
                 .Build();
         }
 
+        private static Pcm16Format ToPcm16Stream(BrstmStructure structure)
+        {
+            short[][] channels = structure.AudioData.Select(x => x.ToShortArray(Endianness.BigEndian)).ToArray();
+            return new Pcm16Format(structure.SampleCount, structure.SampleRate, channels);
+        }
+
         protected override BrstmConfiguration GetConfiguration(BrstmStructure structure)
         {
-            return new BrstmConfiguration
+            var configuration = new BrstmConfiguration();
+            if (structure.Codec == BxstmCodec.Adpcm)
             {
-                SamplesPerInterleave = structure.SamplesPerInterleave,
-                SamplesPerSeekTableEntry = structure.SamplesPerSeekTableEntry,
-                TrackType = structure.HeaderType,
-                SeekTableType = structure.SeekTableType
-            };
+                configuration.SamplesPerInterleave = structure.SamplesPerInterleave;
+                configuration.SamplesPerSeekTableEntry = structure.SamplesPerSeekTableEntry;
+            }
+            configuration.TrackType = structure.HeaderType;
+            configuration.SeekTableType = structure.SeekTableType;
+            return configuration;
         }
 
         private static void ReadRstmHeader(BinaryReader reader, BrstmStructure structure)
@@ -133,10 +149,6 @@ namespace VGAudio.Containers
         {
             reader.BaseStream.Position = structure.HeadChunkOffset + 8 + structure.HeadChunk1Offset;
             structure.Codec = (BxstmCodec)reader.ReadByte();
-            if (structure.Codec != BxstmCodec.Adpcm)
-            {
-                throw new NotSupportedException("File must contain 4-bit ADPCM encoded audio");
-            }
 
             structure.Looping = reader.ReadBoolean();
             structure.ChannelCount = reader.ReadByte();
@@ -216,6 +228,8 @@ namespace VGAudio.Containers
             {
                 reader.BaseStream.Position = baseOffset + channel.Offset;
                 reader.Expect(OffsetMarker);
+                if (structure.Codec != BxstmCodec.Adpcm) continue;
+
                 int coefsOffset = reader.ReadInt32();
                 reader.BaseStream.Position = baseOffset + coefsOffset;
 
@@ -232,6 +246,7 @@ namespace VGAudio.Containers
 
         private static void ReadAdpcChunk(BinaryReader reader, BrstmStructure structure)
         {
+            if (structure.AdpcChunkOffset == 0) return;
             reader.BaseStream.Position = structure.AdpcChunkOffset;
 
             if (Encoding.UTF8.GetString(reader.ReadBytes(4), 0, 4) != "ADPC")
@@ -292,9 +307,12 @@ namespace VGAudio.Containers
 
             reader.BaseStream.Position = structure.AudioDataOffset;
             int audioDataLength = structure.DataChunkSize - (structure.AudioDataOffset - structure.DataChunkOffset);
+            int outputSize = structure.Codec == BxstmCodec.Adpcm
+                ? SampleCountToByteCount(structure.SampleCount)
+                : structure.SampleCount * 2;
 
             structure.AudioData = reader.BaseStream.DeInterleave(audioDataLength, structure.InterleaveSize,
-                structure.ChannelCount, SampleCountToByteCount(structure.SampleCount));
+                structure.ChannelCount, outputSize);
         }
     }
 }

--- a/src/VGAudio/Containers/BrstmReader.cs
+++ b/src/VGAudio/Containers/BrstmReader.cs
@@ -191,7 +191,7 @@ namespace VGAudio.Containers
             foreach (int offset in trackOffsets)
             {
                 reader.BaseStream.Position = baseOffset + offset;
-                var track = new GcAdpcmTrack();
+                var track = new AudioTrack();
 
                 if (structure.HeaderType == BrstmTrackType.Standard)
                 {

--- a/src/VGAudio/Containers/BrstmReader.cs
+++ b/src/VGAudio/Containers/BrstmReader.cs
@@ -80,7 +80,10 @@ namespace VGAudio.Containers
         private static Pcm16Format ToPcm16Stream(BrstmStructure structure)
         {
             short[][] channels = structure.AudioData.Select(x => x.ToShortArray(Endianness.BigEndian)).ToArray();
-            return new Pcm16Format(structure.SampleCount, structure.SampleRate, channels);
+            return new Pcm16Format.Builder(channels, structure.SampleRate)
+                .WithTracks(structure.Tracks)
+                .Loop(structure.Looping, structure.LoopStart, structure.SampleCount)
+                .Build();
         }
 
         protected override BrstmConfiguration GetConfiguration(BrstmStructure structure)
@@ -88,9 +91,10 @@ namespace VGAudio.Containers
             var configuration = new BrstmConfiguration();
             if (structure.Codec == BxstmCodec.Adpcm)
             {
-                configuration.SamplesPerInterleave = structure.SamplesPerInterleave;
                 configuration.SamplesPerSeekTableEntry = structure.SamplesPerSeekTableEntry;
             }
+            configuration.Codec = structure.Codec;
+            configuration.SamplesPerInterleave = structure.SamplesPerInterleave;
             configuration.TrackType = structure.HeaderType;
             configuration.SeekTableType = structure.SeekTableType;
             return configuration;

--- a/src/VGAudio/Containers/BrstmWriter.cs
+++ b/src/VGAudio/Containers/BrstmWriter.cs
@@ -16,7 +16,7 @@ namespace VGAudio.Containers
 
         private int SampleCount => Adpcm.Looping ? LoopEnd : Adpcm.SampleCount;
         private int ChannelCount => Adpcm.ChannelCount;
-        private int TrackCount => Adpcm.Tracks.Count;
+        private int TrackCount => Adpcm.Tracks?.Count ?? 0;
 
         private int LoopStart => Adpcm.LoopStart;
         private int LoopEnd => Adpcm.LoopEnd;
@@ -175,8 +175,9 @@ namespace VGAudio.Containers
                 writer.Write(baseOffset + offsetTableSize + TrackInfoSize * i);
             }
 
-            foreach (GcAdpcmTrack track in Adpcm.Tracks)
+            for (int i = 0; i < TrackCount; i++)
             {
+                AudioTrack track = Adpcm.Tracks[i];
                 if (HeaderType == BrstmTrackType.Standard)
                 {
                     writer.Write((byte)track.Volume);

--- a/src/VGAudio/Containers/BrstmWriter.cs
+++ b/src/VGAudio/Containers/BrstmWriter.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using VGAudio.Containers.Bxstm;
 using VGAudio.Formats;
@@ -12,33 +13,37 @@ namespace VGAudio.Containers
     public class BrstmWriter : AudioWriter<BrstmWriter, BrstmConfiguration>
     {
         private GcAdpcmFormat Adpcm { get; set; }
+        private Pcm16Format Pcm16 { get; set; }
+        private IAudioFormat AudioFormat { get; set; }
+
         protected override int FileSize => RstmHeaderSize + HeadChunkSize + AdpcChunkSize + DataChunkSize;
 
-        private int SampleCount => Adpcm.Looping ? LoopEnd : Adpcm.SampleCount;
-        private int ChannelCount => Adpcm.ChannelCount;
-        private int TrackCount => Adpcm.Tracks?.Count ?? 0;
+        private int SampleCount => AudioFormat.Looping ? LoopEnd : AudioFormat.SampleCount;
+        private int ChannelCount => AudioFormat.ChannelCount;
+        private int TrackCount => Tracks?.Count ?? 0;
+        private List<AudioTrack> Tracks { get; set; }
 
-        private int LoopStart => Adpcm.LoopStart;
-        private int LoopEnd => Adpcm.LoopEnd;
+        private int LoopStart => AudioFormat.LoopStart;
+        private int LoopEnd => AudioFormat.LoopEnd;
 
-        private static BxstmCodec Codec => BxstmCodec.Adpcm;
+        private BxstmCodec Codec => Configuration.Codec;
         private int AudioDataOffset => DataChunkOffset + 0x20;
 
         /// <summary>
-        /// Size of a single channel's ADPCM audio data with padding when written to a file
+        /// Size of a single channel's audio data with padding when written to a file
         /// </summary>
-        private int AudioDataSize => GetNextMultiple(SampleCountToByteCount(SampleCount), 0x20);
+        private int AudioDataSize => GetNextMultiple(SamplesToBytes(SampleCount), 0x20);
 
         private int SamplesPerInterleave => Configuration.SamplesPerInterleave;
-        private int InterleaveSize => SampleCountToByteCount(SamplesPerInterleave);
+        private int InterleaveSize => SamplesToBytes(SamplesPerInterleave);
         private int InterleaveCount => SampleCount.DivideByRoundUp(SamplesPerInterleave);
 
         private int LastBlockSamples => SampleCount - ((InterleaveCount - 1) * SamplesPerInterleave);
-        private int LastBlockSizeWithoutPadding => SampleCountToByteCount(LastBlockSamples);
+        private int LastBlockSizeWithoutPadding => SamplesToBytes(LastBlockSamples);
         private int LastBlockSize => GetNextMultiple(LastBlockSizeWithoutPadding, 0x20);
 
-        private int SamplesPerSeekTableEntry => Configuration.SamplesPerSeekTableEntry;
-        private int BytesPerSeekTableEntry => 4;
+        private int SamplesPerSeekTableEntry => Codec == BxstmCodec.Adpcm ? Configuration.SamplesPerSeekTableEntry : 0;
+        private int BytesPerSeekTableEntry => Codec == BxstmCodec.Adpcm ? 4 : 0;
         private int SeekTableEntryCount => Configuration.SeekTableType == BrstmSeekTableType.Standard
             ? SampleCount.DivideByRoundUp(SamplesPerSeekTableEntry)
             : (SampleCountToByteCount(SampleCount) / SamplesPerSeekTableEntry) + 1;
@@ -55,10 +60,10 @@ namespace VGAudio.Containers
         private BrstmTrackType HeaderType => Configuration.TrackType;
         private int TrackInfoSize => HeaderType == BrstmTrackType.Short ? 4 : 0x0c;
         private int HeadChunk3Size => 4 + (8 * ChannelCount) + (ChannelInfoSize * ChannelCount);
-        private int ChannelInfoSize => 0x38;
+        private int ChannelInfoSize => Codec == BxstmCodec.Adpcm ? 0x38 : 8;
 
-        private int AdpcChunkOffset => RstmHeaderSize + HeadChunkSize;
-        private int AdpcChunkSize => GetNextMultiple(8 + SeekTableEntryCount * ChannelCount * BytesPerSeekTableEntry, 0x20);
+        private int AdpcChunkOffset => Codec == BxstmCodec.Adpcm ? RstmHeaderSize + HeadChunkSize : 0;
+        private int AdpcChunkSize => Codec == BxstmCodec.Adpcm ? GetNextMultiple(8 + SeekTableEntryCount * ChannelCount * BytesPerSeekTableEntry, 0x20) : 0;
 
         private int DataChunkOffset => RstmHeaderSize + HeadChunkSize + AdpcChunkSize;
         private int DataChunkSize => 0x20 + AudioDataSize * ChannelCount;
@@ -71,24 +76,35 @@ namespace VGAudio.Containers
 
         protected override void SetupWriter(AudioData audio)
         {
-            Adpcm = audio.GetFormat<GcAdpcmFormat>();
-
-            if (!LoopPointsAreAligned(LoopStart, Configuration.LoopPointAlignment))
+            if (Codec == BxstmCodec.Adpcm)
             {
-                Adpcm = Adpcm.GetCloneBuilder().WithAlignment(Configuration.LoopPointAlignment).Build();
+                Adpcm = audio.GetFormat<GcAdpcmFormat>();
+                AudioFormat = Adpcm;
+                Tracks = Adpcm.Tracks;
+
+                if (!LoopPointsAreAligned(LoopStart, Configuration.LoopPointAlignment))
+                {
+                    Adpcm = Adpcm.GetCloneBuilder().WithAlignment(Configuration.LoopPointAlignment).Build();
+                }
+
+                Parallel.For(0, ChannelCount, i =>
+                {
+                    GcAdpcmChannelBuilder builder = Adpcm.Channels[i].GetCloneBuilder()
+                        .WithSamplesPerSeekTableEntry(SamplesPerSeekTableEntry)
+                        .WithLoop(Adpcm.Looping, Adpcm.UnalignedLoopStart, Adpcm.UnalignedLoopEnd);
+
+                    builder.LoopAlignmentMultiple = Configuration.LoopPointAlignment;
+                    builder.EnsureLoopContextIsSelfCalculated = Configuration.RecalculateLoopContext;
+                    builder.EnsureSeekTableIsSelfCalculated = Configuration.RecalculateSeekTable;
+                    Adpcm.Channels[i] = builder.Build();
+                });
             }
-
-            Parallel.For(0, ChannelCount, i =>
+            else if (Codec == BxstmCodec.Pcm16Bit)
             {
-                GcAdpcmChannelBuilder builder = Adpcm.Channels[i].GetCloneBuilder()
-                    .WithSamplesPerSeekTableEntry(SamplesPerSeekTableEntry)
-                    .WithLoop(Adpcm.Looping, Adpcm.UnalignedLoopStart, Adpcm.UnalignedLoopEnd);
-
-                builder.LoopAlignmentMultiple = Configuration.LoopPointAlignment;
-                builder.EnsureLoopContextIsSelfCalculated = Configuration.RecalculateLoopContext;
-                builder.EnsureSeekTableIsSelfCalculated = Configuration.RecalculateSeekTable;
-                Adpcm.Channels[i] = builder.Build();
-            });
+                Pcm16 = audio.GetFormat<Pcm16Format>();
+                AudioFormat = Pcm16;
+                Tracks = Pcm16.Tracks;
+            }
         }
 
         protected override void WriteStream(Stream stream)
@@ -142,10 +158,10 @@ namespace VGAudio.Containers
         private void WriteHeadChunk1(BinaryWriter writer)
         {
             writer.Write((byte)Codec);
-            writer.Write(Adpcm.Looping);
+            writer.Write(AudioFormat.Looping);
             writer.Write((byte)ChannelCount);
             writer.Write((byte)0); //padding
-            writer.Write((ushort)Adpcm.SampleRate);
+            writer.Write((ushort)AudioFormat.SampleRate);
             writer.Write((short)0);//padding
             writer.Write(LoopStart);
             writer.Write(SampleCount);
@@ -177,7 +193,7 @@ namespace VGAudio.Containers
 
             for (int i = 0; i < TrackCount; i++)
             {
-                AudioTrack track = Adpcm.Tracks[i];
+                AudioTrack track = Tracks[i];
                 if (HeaderType == BrstmTrackType.Standard)
                 {
                     writer.Write((byte)track.Volume);
@@ -209,8 +225,14 @@ namespace VGAudio.Containers
 
             for (int i = 0; i < ChannelCount; i++)
             {
-                GcAdpcmChannel channel = Adpcm.Channels[i];
                 writer.Write(OffsetMarker);
+                if (Codec != BxstmCodec.Adpcm)
+                {
+                    writer.Write(0);
+                    continue;
+                }
+
+                GcAdpcmChannel channel = Adpcm.Channels[i];
                 writer.Write(baseOffset + offsetTableSize + ChannelInfoSize * i + 8);
                 writer.Write(channel.Coefs.ToByteArray(Endianness.BigEndian));
                 writer.Write(channel.Gain);
@@ -226,6 +248,7 @@ namespace VGAudio.Containers
 
         private void WriteAdpcChunk(BinaryWriter writer)
         {
+            if (Codec != BxstmCodec.Adpcm) return;
             writer.WriteUTF8("ADPC");
             writer.Write(AdpcChunkSize);
 
@@ -242,9 +265,31 @@ namespace VGAudio.Containers
 
             writer.BaseStream.Position = AudioDataOffset;
 
-            byte[][] channels = Adpcm.Channels.Select(x => x.GetAdpcmAudio()).ToArray();
+            byte[][] channels = null;
+            switch (Codec)
+            {
+                case BxstmCodec.Adpcm:
+                    channels = Adpcm.Channels.Select(x => x.GetAdpcmAudio()).ToArray();
+                    break;
+                case BxstmCodec.Pcm16Bit:
+                    channels = Pcm16.Channels.Select(x => x.ToByteArray(Endianness.BigEndian)).ToArray();
+                    break;
+            }
 
             channels.Interleave(writer.BaseStream, InterleaveSize, AudioDataSize);
+        }
+
+        private int SamplesToBytes(int sampleCount)
+        {
+            switch (Codec)
+            {
+                case BxstmCodec.Adpcm:
+                    return SampleCountToByteCount(sampleCount);
+                case BxstmCodec.Pcm16Bit:
+                    return sampleCount * 2;
+                default:
+                    return 0;
+            }
         }
     }
 }

--- a/src/VGAudio/Containers/Bxstm/BCFstmReader.cs
+++ b/src/VGAudio/Containers/Bxstm/BCFstmReader.cs
@@ -219,7 +219,7 @@ namespace VGAudio.Containers.Bxstm
             {
                 reader.BaseStream.Position = part2Offset + offset;
 
-                var track = new GcAdpcmTrack();
+                var track = new AudioTrack();
                 track.Volume = reader.ReadByte();
                 track.Panning = reader.ReadByte();
                 reader.BaseStream.Position += 2;

--- a/src/VGAudio/Containers/Bxstm/BCFstmStructure.cs
+++ b/src/VGAudio/Containers/Bxstm/BCFstmStructure.cs
@@ -97,11 +97,6 @@
         public RegnChunk Regn { get; set; }
 
         /// <summary>
-        /// The audio codec.
-        /// </summary>
-        public BxstmCodec Codec { get; set; }
-
-        /// <summary>
         /// The number of audio sections in the file.
         /// </summary>
         public int SectionCount { get; set; }

--- a/src/VGAudio/Containers/Bxstm/BCFstmWriter.cs
+++ b/src/VGAudio/Containers/Bxstm/BCFstmWriter.cs
@@ -20,7 +20,7 @@ namespace VGAudio.Containers.Bxstm
         public BCFstmType Type { get; }
         private int SampleCount => Adpcm.Looping ? LoopEnd : Adpcm.SampleCount;
         private int ChannelCount => Adpcm.ChannelCount;
-        private int TrackCount => Adpcm.Tracks.Count;
+        private int TrackCount => Adpcm.Tracks?.Count ?? 0;
 
         private int LoopStart => Adpcm.LoopStart;
         private int LoopEnd => Adpcm.LoopEnd;
@@ -260,7 +260,7 @@ namespace VGAudio.Containers.Bxstm
                 writer.Write(channelTableSize + trackTableSize + 8 * i);
             }
 
-            if (IncludeTrackInformation)
+            if (IncludeTrackInformation && Adpcm.Tracks != null)
             {
                 foreach (var track in Adpcm.Tracks)
                 {

--- a/src/VGAudio/Containers/Bxstm/BrstmStructure.cs
+++ b/src/VGAudio/Containers/Bxstm/BrstmStructure.cs
@@ -76,11 +76,6 @@
         public int DataChunkSize { get; set; }
 
         /// <summary>
-        /// The audio codec.
-        /// </summary>
-        public BxstmCodec Codec { get; set; }
-
-        /// <summary>
         /// The type of description used for the tracks
         /// in part 2 of the HEAD chunk.
         /// </summary>

--- a/src/VGAudio/Containers/Bxstm/BxstmConfiguration.cs
+++ b/src/VGAudio/Containers/Bxstm/BxstmConfiguration.cs
@@ -8,7 +8,8 @@ namespace VGAudio.Containers.Bxstm
     /// </summary>
     public abstract class BxstmConfiguration
     {
-        private int _samplesPerInterleave = 0x3800;
+        private const int Default = -1;
+        private int _samplesPerInterleave = Default;
         private int _samplesPerSeekTableEntry = 0x3800;
 
         /// <summary>
@@ -37,7 +38,20 @@ namespace VGAudio.Containers.Bxstm
         /// or not divisible by 14.</exception>
         public int SamplesPerInterleave
         {
-            get => _samplesPerInterleave;
+            get
+            {
+                if (_samplesPerInterleave != Default) return _samplesPerInterleave;
+
+                switch (Codec)
+                {
+                    case BxstmCodec.Adpcm:
+                        return 0x3800;
+                    case BxstmCodec.Pcm16Bit:
+                        return 0x1000;
+                    default:
+                        return 0;
+                }
+            }
             set
             {
                 if (value < 1)
@@ -45,7 +59,7 @@ namespace VGAudio.Containers.Bxstm
                     throw new ArgumentOutOfRangeException(nameof(value), value,
                         "Number of samples per interleave must be positive");
                 }
-                if (value % SamplesPerFrame != 0)
+                if (Codec == BxstmCodec.Adpcm && value % SamplesPerFrame != 0)
                 {
                     throw new ArgumentOutOfRangeException(nameof(value), value,
                         "Number of samples per interleave must be divisible by 14");
@@ -81,5 +95,6 @@ namespace VGAudio.Containers.Bxstm
         /// this number. Default is 14,336 (0x3800).
         /// </summary>
         public int LoopPointAlignment { get; set; } = 0x3800;
+        public BxstmCodec Codec { get; set; } = BxstmCodec.Adpcm;
     }
 }

--- a/src/VGAudio/Containers/Bxstm/BxstmStructure.cs
+++ b/src/VGAudio/Containers/Bxstm/BxstmStructure.cs
@@ -77,6 +77,10 @@ namespace VGAudio.Containers.Bxstm
         /// </summary>
         public int BytesPerSeekTableEntry { get; set; }
         /// <summary>
+        /// The audio codec.
+        /// </summary>
+        public BxstmCodec Codec { get; set; }
+        /// <summary>
         /// A list of all tracks defined in the file.
         /// </summary>
         public List<GcAdpcmTrack> Tracks { get; set; } = new List<GcAdpcmTrack>();

--- a/src/VGAudio/Containers/Bxstm/BxstmStructure.cs
+++ b/src/VGAudio/Containers/Bxstm/BxstmStructure.cs
@@ -1,5 +1,5 @@
 ﻿using System.Collections.Generic;
-using VGAudio.Formats.GcAdpcm;
+using VGAudio.Formats;
 
 namespace VGAudio.Containers.Bxstm
 {
@@ -83,7 +83,7 @@ namespace VGAudio.Containers.Bxstm
         /// <summary>
         /// A list of all tracks defined in the file.
         /// </summary>
-        public List<GcAdpcmTrack> Tracks { get; set; } = new List<GcAdpcmTrack>();
+        public List<AudioTrack> Tracks { get; set; } = new List<AudioTrack>();
         /// <summary>
         /// The ADPCM information for each channel.
         /// </summary>

--- a/src/VGAudio/Containers/DspReader.cs
+++ b/src/VGAudio/Containers/DspReader.cs
@@ -50,8 +50,9 @@ namespace VGAudio.Containers
                 channels[c] = channelBuilder.Build();
             }
 
-            return new GcAdpcmFormat(structure.SampleCount, structure.SampleRate, channels)
-                .WithLoop(structure.Looping, structure.LoopStart, structure.LoopEnd);
+            return new GcAdpcmFormatBuilder(channels, structure.SampleRate)
+                .Loop(structure.Looping, structure.LoopStart, structure.LoopEnd)
+                .Build();
         }
 
         private static void ReadHeader(BinaryReader reader, DspStructure structure)

--- a/src/VGAudio/Containers/GenhReader.cs
+++ b/src/VGAudio/Containers/GenhReader.cs
@@ -42,8 +42,9 @@ namespace VGAudio.Containers
                 channels[c] = channel;
             }
 
-            return new GcAdpcmFormat(structure.SampleCount, structure.SampleRate, channels)
-                .WithLoop(structure.Looping, structure.LoopStart, structure.LoopEnd);
+            return new GcAdpcmFormatBuilder(channels, structure.SampleRate)
+                .Loop(structure.Looping, structure.LoopStart, structure.LoopEnd)
+                .Build();
         }
 
         private static void ReadHeader(BinaryReader reader, GenhStructure structure)

--- a/src/VGAudio/Containers/IdspReader.cs
+++ b/src/VGAudio/Containers/IdspReader.cs
@@ -52,8 +52,9 @@ namespace VGAudio.Containers
                 channels[c] = channelBuilder.Build();
             }
 
-            return new GcAdpcmFormat(structure.SampleCount, structure.SampleRate, channels)
-                .WithLoop(structure.Looping, structure.LoopStart, structure.LoopEnd);
+            return new GcAdpcmFormatBuilder(channels, structure.SampleRate)
+                .Loop(structure.Looping, structure.LoopStart, structure.LoopEnd)
+                .Build();
         }
 
         protected override IdspConfiguration GetConfiguration(IdspStructure structure)

--- a/src/VGAudio/Containers/WaveReader.cs
+++ b/src/VGAudio/Containers/WaveReader.cs
@@ -65,7 +65,7 @@ namespace VGAudio.Containers
                 channels[i] = structure.AudioData[i];
             }
 
-            var waveFormat = new Pcm16Format(structure.SampleCount, structure.SampleRate, channels);
+            var waveFormat = new Pcm16Format(channels, structure.SampleRate);
 
             return waveFormat;
         }

--- a/src/VGAudio/Formats/AudioFormatBase.cs
+++ b/src/VGAudio/Formats/AudioFormatBase.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace VGAudio.Formats
 {
@@ -7,6 +8,7 @@ namespace VGAudio.Formats
         where TFormat : AudioFormatBase<TFormat, TBuilder>
         where TBuilder : AudioFormatBaseBuilder<TFormat, TBuilder>
     {
+        private readonly List<AudioTrack> _tracks;
         public int SampleCount { get; }
         public int SampleRate { get; }
         public int ChannelCount { get; }
@@ -28,6 +30,7 @@ namespace VGAudio.Formats
             SampleCount = sampleCount;
             SampleRate = sampleRate;
             ChannelCount = channelCount;
+            Tracks = _tracks ?? AudioTrack.GetDefaultTrackList(ChannelCount).ToList();
         }
 
         protected AudioFormatBase(TBuilder builder)
@@ -36,7 +39,8 @@ namespace VGAudio.Formats
             Looping = builder.Looping;
             LoopStart = builder.LoopStart;
             LoopEnd = builder.LoopEnd;
-            Tracks = builder.Tracks;
+            _tracks = builder.Tracks;
+            Tracks = _tracks ?? AudioTrack.GetDefaultTrackList(ChannelCount).ToList();
         }
 
         public TFormat GetChannels(params int[] channelRange)
@@ -89,7 +93,7 @@ namespace VGAudio.Formats
             builder.Looping = Looping;
             builder.LoopStart = LoopStart;
             builder.LoopEnd = LoopEnd;
-            builder.Tracks = Tracks;
+            builder.Tracks = _tracks;
             return builder;
         }
     }

--- a/src/VGAudio/Formats/AudioFormatBase.cs
+++ b/src/VGAudio/Formats/AudioFormatBase.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace VGAudio.Formats
 {
@@ -12,6 +13,7 @@ namespace VGAudio.Formats
         public int LoopStart { get; }
         public int LoopEnd { get; }
         public bool Looping { get; }
+        public List<AudioTrack> Tracks { get; }
 
         IAudioFormat IAudioFormat.EncodeFromPcm16(Pcm16Format pcm16) => EncodeFromPcm16(pcm16);
         IAudioFormat IAudioFormat.GetChannels(params int[] channelRange) => GetChannels(channelRange);
@@ -34,6 +36,7 @@ namespace VGAudio.Formats
             Looping = builder.Looping;
             LoopStart = builder.LoopStart;
             LoopEnd = builder.LoopEnd;
+            Tracks = builder.Tracks;
         }
 
         public TFormat GetChannels(params int[] channelRange)
@@ -86,6 +89,7 @@ namespace VGAudio.Formats
             builder.Looping = Looping;
             builder.LoopStart = LoopStart;
             builder.LoopEnd = LoopEnd;
+            builder.Tracks = Tracks;
             return builder;
         }
     }

--- a/src/VGAudio/Formats/AudioFormatBase.cs
+++ b/src/VGAudio/Formats/AudioFormatBase.cs
@@ -25,22 +25,17 @@ namespace VGAudio.Formats
         public abstract Pcm16Format ToPcm16();
         public abstract TFormat EncodeFromPcm16(Pcm16Format pcm16);
 
-        protected AudioFormatBase(int sampleCount, int sampleRate, int channelCount)
-        {
-            SampleCount = sampleCount;
-            SampleRate = sampleRate;
-            ChannelCount = channelCount;
-            Tracks = _tracks ?? AudioTrack.GetDefaultTrackList(ChannelCount).ToList();
-        }
-
+        protected AudioFormatBase() { }
         protected AudioFormatBase(TBuilder builder)
-            : this(builder.SampleCount, builder.SampleRate, builder.ChannelCount)
         {
+            SampleCount = builder.SampleCount;
+            SampleRate = builder.SampleRate;
+            ChannelCount = builder.ChannelCount;
             Looping = builder.Looping;
             LoopStart = builder.LoopStart;
             LoopEnd = builder.LoopEnd;
             _tracks = builder.Tracks;
-            Tracks = _tracks ?? AudioTrack.GetDefaultTrackList(ChannelCount).ToList();
+            Tracks = _tracks != null && _tracks.Count > 0 ? _tracks : AudioTrack.GetDefaultTrackList(ChannelCount).ToList();
         }
 
         public TFormat GetChannels(params int[] channelRange)

--- a/src/VGAudio/Formats/AudioFormatBaseBuilder.cs
+++ b/src/VGAudio/Formats/AudioFormatBaseBuilder.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace VGAudio.Formats
 {
@@ -12,6 +14,7 @@ namespace VGAudio.Formats
         internal int LoopEnd { get; set; }
         internal int SampleCount { get; set; }
         internal int SampleRate { get; set; }
+        internal List<AudioTrack> Tracks { get; set; }
 
         public abstract TFormat Build();
 
@@ -49,6 +52,12 @@ namespace VGAudio.Formats
             Looping = loop;
             LoopStart = 0;
             LoopEnd = loop ? SampleCount : 0;
+            return this as TBuilder;
+        }
+
+        public TBuilder WithTracks(IEnumerable<AudioTrack> tracks)
+        {
+            Tracks = tracks?.ToList();
             return this as TBuilder;
         }
     }

--- a/src/VGAudio/Formats/GcAdpcmFormat.cs
+++ b/src/VGAudio/Formats/GcAdpcmFormat.cs
@@ -23,14 +23,10 @@ namespace VGAudio.Formats
 
         public int UnalignedLoopStart => base.LoopStart;
         public int UnalignedLoopEnd => base.LoopEnd;
-        public int UnalignedSampleCount =>  base.SampleCount;
+        public int UnalignedSampleCount => base.SampleCount;
 
-        public GcAdpcmFormat() : base(0, 0, 0) => Channels = new GcAdpcmChannel[0];
-        public GcAdpcmFormat(int sampleCount, int sampleRate, GcAdpcmChannel[] channels)
-            : base(sampleCount, sampleRate, channels.Length)
-        {
-            Channels = channels;
-        }
+        public GcAdpcmFormat() => Channels = new GcAdpcmChannel[0];
+        public GcAdpcmFormat(GcAdpcmChannel[] channels, int sampleRate) : this(new GcAdpcmFormatBuilder(channels, sampleRate)) { }
 
         internal GcAdpcmFormat(GcAdpcmFormatBuilder b) : base(b)
         {
@@ -46,7 +42,7 @@ namespace VGAudio.Formats
                     .Build();
             });
         }
-        
+
         public override Pcm16Format ToPcm16()
         {
             var pcmChannels = new short[Channels.Length][];

--- a/src/VGAudio/Formats/GcAdpcmFormatBuilder.cs
+++ b/src/VGAudio/Formats/GcAdpcmFormatBuilder.cs
@@ -8,7 +8,6 @@ namespace VGAudio.Formats
     public class GcAdpcmFormatBuilder : AudioFormatBaseBuilder<GcAdpcmFormat, GcAdpcmFormatBuilder>
     {
         public GcAdpcmChannel[] Channels { get; set; }
-        public List<GcAdpcmTrack> Tracks { get; set; }
         public int AlignmentMultiple { get; set; }
         internal override int ChannelCount => Channels.Length;
 
@@ -32,12 +31,6 @@ namespace VGAudio.Formats
         }
 
         public override GcAdpcmFormat Build() => new GcAdpcmFormat(this);
-
-        public GcAdpcmFormatBuilder WithTracks(IEnumerable<GcAdpcmTrack> tracks)
-        {
-            Tracks = tracks.ToList();
-            return this;
-        }
 
         public GcAdpcmFormatBuilder WithAlignment(int loopAlignmentMultiple)
         {

--- a/src/VGAudio/Formats/GcAdpcmTrack.cs
+++ b/src/VGAudio/Formats/GcAdpcmTrack.cs
@@ -1,13 +1,16 @@
-﻿namespace VGAudio.Formats.GcAdpcm
+﻿using System;
+using System.Collections.Generic;
+using VGAudio.Utilities;
+
+namespace VGAudio.Formats
 {
     /// <summary>
-    /// Defines an audio track in an ADPCM audio
-    /// stream. Each track is composed of one
-    /// or two channels.
+    /// Defines an audio track in an audio stream.
+    /// Each track is composed of one or two channels.
     /// </summary>
-    public class GcAdpcmTrack
+    public class AudioTrack
     {
-        public GcAdpcmTrack(int channelCount, int channelLeft, int channelRight, int panning, int volume)
+        public AudioTrack(int channelCount, int channelLeft, int channelRight, int panning, int volume)
         {
             ChannelCount = channelCount;
             ChannelLeft = channelLeft;
@@ -16,14 +19,14 @@
             Volume = volume;
         }
 
-        public GcAdpcmTrack(int channelCount, int channelLeft, int channelRight)
+        public AudioTrack(int channelCount, int channelLeft, int channelRight)
         {
             ChannelCount = channelCount;
             ChannelLeft = channelLeft;
             ChannelRight = channelRight;
         }
 
-        public GcAdpcmTrack() { }
+        public AudioTrack() { }
 
         /// <summary>
         /// The volume of the track. Ranges from
@@ -59,5 +62,20 @@
         /// a stereo track.
         /// </summary>
         public int ChannelRight { get; set; }
+
+        public static IEnumerable<AudioTrack> GetDefaultTrackList(int channelCount)
+        {
+            int trackCount = channelCount.DivideByRoundUp(2);
+            for (int i = 0; i < trackCount; i++)
+            {
+                int trackChannelCount = Math.Min(channelCount - i * 2, 2);
+                yield return new AudioTrack
+                {
+                    ChannelCount = trackChannelCount,
+                    ChannelLeft = i * 2,
+                    ChannelRight = trackChannelCount >= 2 ? i * 2 + 1 : 0
+                };
+            }
+        }
     }
 }

--- a/src/VGAudio/Formats/Pcm16Format.cs
+++ b/src/VGAudio/Formats/Pcm16Format.cs
@@ -13,13 +13,8 @@ namespace VGAudio.Formats
     {
         public short[][] Channels { get; }
 
-        public Pcm16Format() : base(0, 0, 0) => Channels = new short[0][];
-        public Pcm16Format(int sampleCount, int sampleRate, short[][] channels)
-            : base(sampleCount, sampleRate, channels.Length)
-        {
-            Channels = channels;
-        }
-
+        public Pcm16Format() => Channels = new short[0][];
+        public Pcm16Format(short[][] channels, int sampleRate) : this(new Builder(channels, sampleRate)) { }
         private Pcm16Format(Builder b) : base(b) => Channels = b.Channels;
 
         public override Pcm16Format ToPcm16() => GetCloneBuilder().Build();


### PR DESCRIPTION
Read and write 16-bit PCM BRSTM files
Rename GcAdpcmTrack to AudioTrack, and add it to the base audio format
Get rid of old audio format constructors in favor of using the audio format builders
Special thanks to @libertyernie for a reference implementation