### PR TITLE
Add PCM support for BFSTM and BCSTM files

### DIFF
--- a/docs/formats/bfstm.bt
+++ b/docs/formats/bfstm.bt
@@ -1,0 +1,325 @@
+//------------------------------------------------
+//--- 010 Editor v7.0.2 Binary Template
+//
+//      File: bfstm.bt
+//   Authors: Alex Barney
+//   Version: 1.0
+//   Purpose: Parse BFSTM and BCSTM audio files
+//  Category: Audio
+// File Mask: *.bfstm, *.bcstm
+//  ID Bytes: 46 53 54 4D, 43 53 54 4D //FSTM, CSTM
+//   History: 
+//   1.0   Initial Release
+//------------------------------------------------
+
+typedef char ID[4];
+struct Header
+{
+    ID RstmId;
+    int16 BOM;
+    int16 HeaderSize;
+    int32 Version;
+    int32 FileSize;
+    int16 ChunkCount;
+    int16 Padding;
+    
+    local int i;
+    for( i = 0; i < ChunkCount; i++)
+    {
+        switch(ReadShort())
+        {
+            case 0x4000:
+                int16 InfoMarker <format=hex>;
+                FSkip(2);
+                int32 InfoChunkOffset;
+                int32 InfoChunkSize;
+                break;
+            case 0x4001:
+                int16 SeekMarker <format=hex>;
+                FSkip(2);
+                int32 SeekChunkOffset;
+                int32 SeekChunkSize;
+                break;
+            case 0x4002:
+                int16 DataMarker <format=hex>;
+                FSkip(2);
+                int32 DataChunkOffset;
+                int32 DataChunkSize;
+                break;
+            case 0x4003:
+                int16 RegnMarker <format=hex>;
+                FSkip(2);
+                int32 RegnChunkOffset;
+                int32 RegnChunkSize;
+                break;
+            case 0x4004:
+                int16 PdatMarker <format=hex>;
+                FSkip(2);
+                int32 PdatChunkOffset;
+                int32 PdatChunkSize;
+                break;
+        }
+    }
+};
+
+enum <byte> AudioCodec
+{
+    PCM_8Bit   = 0,
+    PCM_16Bit  = 1,
+    GcAdpcm    = 2
+};
+
+struct Pointer
+{
+    int16 Marker <format=hex>;
+    int16 Padding;
+    int32 Offset;
+};
+
+struct Track
+{
+    byte Volume;
+    byte Panning;
+    int16 Unknown1;
+    int32 Unknown2;
+    int32 Unknown3;
+    int32 ChannelCount;
+    byte LeftChannelId;
+    byte RightChannelId;
+    int16 Padding;
+};
+
+struct AdpcmChannel
+{
+    uint16 Coefficients[16];
+    int16 Gain;
+    int16 InitialPredictorScale <format=hex>;
+    int16 History1;
+    int16 History2;
+    int16 LoopPredictorScale <format=hex>;
+    int16 LoopHistory1;
+    int16 LoopHistory2;
+};
+
+struct INFOChunk1(Header &head)
+{
+    AudioCodec Codec;
+    byte Loops;
+    byte ChannelCount;
+    byte SectionCount;
+    int32 SampleRate;
+    int32 LoopStart;
+    int32 SampleCount;    
+    int32 BlockCount;
+    int32 BlockSizeBytes;
+    int32 BlockSizeSamples;
+    int32 FinalBlockSizeBytesWithoutPadding;
+    int32 FinalBlockSizeSamples;
+    int32 FinalBlockSizeBytesWithPadding;
+    int32 BytesPerSeekTableEntry;
+    int32 SamplesPerSeekTableEntry;
+
+    Pointer pAudioData;
+    
+    if(ReadShort() == 0x100)
+    {
+        int16 ExtraMarker <format=hex>;
+        byte Extra[10];
+    }
+
+    if(head.Version >> 16 == 4)
+    {
+        int32 UnalignedLoopStart;
+        int32 UnalignedSampleCount; 
+    }
+};
+
+struct INFOChunk2
+{
+    local int32 base = FTell();
+    int32 TrackCount;
+    local int i;
+    for(i = 0; i < TrackCount; i++)
+    {
+        Pointer pTracks;
+    }
+    for(i = 0; i < TrackCount; i++)
+    {
+        FSeek(base + pTracks[i].Offset);
+        Track tracks;
+    }
+};
+
+struct INFOChunk3(AudioCodec codec)
+{
+    local int32 base = FTell();
+    int32 ChannelCount;
+    local int i;
+    for(i = 0; i < ChannelCount; i++)
+    {
+        Pointer ppChannels;
+    }
+
+    for( i = 0; i < ChannelCount; i++ )
+    {
+        FSeek(base + ppChannels[i].Offset);
+        Pointer pChannels;
+    }
+
+    for( i = 0; i < ChannelCount; i++ )
+    {
+        if(pChannels[i].Offset == -1) {continue;}
+        FSeek(base + ppChannels[i].Offset + pChannels[i].Offset);
+        AdpcmChannel Channel;
+    }
+};
+
+struct INFOChunk(Header &head)
+{    
+    ID InfoId;
+    int32 Size;
+    local int32 base = FTell();
+    Pointer pChunk1;
+    Pointer pChunk2;
+    Pointer pChunk3;
+    
+    FSeek(base + pChunk1.Offset);
+    INFOChunk1 Chunk1(head);
+
+    if(pChunk2.Offset != -1)
+    {
+        FSeek(base + pChunk2.Offset);
+        INFOChunk2 Chunk2;
+    }
+
+    FSeek(base + pChunk3.Offset);
+    INFOChunk3 Chunk3(Chunk1.Codec);
+};
+
+struct REGNEntryChannel
+{
+    int16 PredScale;
+    int16 Unknown1;
+    int16 Unknown2;
+};
+
+struct REGNEntry (int32 channelCount)
+{
+    int32 StartSample;
+    int32 EndSample;
+    local int32 i;
+    for( i = 0; i < channelCount; i++ )
+    {
+        REGNEntryChannel Channel;
+    }
+};
+
+struct REGNChunk (int32 sectionCount, int32 channelCount)
+{
+    local int32 base = FTell();
+    ID InfoId;
+    int32 Size;
+    local int32 i;
+    for( i = 0; i < sectionCount; i++ )
+    {
+        FSeek(base + 0x20 + 0x100 * i);
+        REGNEntry Entry(channelCount);
+    }
+};
+
+struct SeekTableEntryChannel
+{
+    int16 History1;
+    int16 History2;
+};
+
+struct SeekTableEntry (int32 channelCount)
+{
+    local int32 i;
+    for( i = 0; i < channelCount; i++ )
+    {
+        SeekTableEntryChannel Channel;
+    }
+};
+
+struct SEEKChunk (int32 channelCount)
+{    
+    local int32 entrySize = channelCount * 4; 
+    ID SeekId;
+    int32 Size;
+    local int32 entryCount = (Size - 8) / entrySize; 
+    local int32 i;
+    for( i = 0; i < entryCount; i++ )
+    {
+        SeekTableEntry Entry(channelCount);
+    }
+};
+
+struct Channel(int32 size, int32 padding)
+{
+    byte Data[size];
+    if (padding)
+        byte Padding[padding];
+};
+
+
+struct Block(int32 count, int32 size, int32 padding)
+{
+    local int i;
+    for(i = 0; i < count; i++)
+    {
+        Channel Channels(size, padding);
+    }
+};
+
+struct DATAChunk (INFOChunk1 &head)
+{    
+    ID DataId;
+    int32 Size;
+    FSkip(head.pAudioData.Offset);
+
+    local int32 i;
+    for (i = 0; i < head.BlockCount - 1; i++)
+    {
+        Block Blocks(head.ChannelCount, head.BlockSizeBytes, 0);
+    }
+
+    local int padding = head.FinalBlockSizeBytesWithPadding - head.FinalBlockSizeBytesWithoutPadding;
+    Block Blocks(head.ChannelCount, head.FinalBlockSizeBytesWithoutPadding, padding); 
+};
+
+BigEndian();
+switch(ReadUShort(4))
+{
+    case 0xFEFF: break;
+    case 0xFFFE: 
+        LittleEndian();
+        break;
+    default: Exit(1);
+}
+
+Header Head;
+
+if(exists(Head.InfoMarker))
+{
+    FSeek(Head.InfoChunkOffset);
+    INFOChunk Info(Head);
+}
+
+if(exists(Head.SeekMarker))
+{
+    FSeek(Head.SeekChunkOffset);
+    SEEKChunk Seek(Info.Chunk1.ChannelCount);
+}
+
+if(exists(Head.RegnMarker))
+{
+    FSeek(Head.RegnChunkOffset);
+    REGNChunk Regn(Info.Chunk1.SectionCount, Info.Chunk1.ChannelCount);
+}
+
+if(exists(Head.DataMarker))
+{
+    FSeek(Head.DataChunkOffset);
+    DATAChunk Data(Info.Chunk1);
+}

--- a/docs/formats/brstm.bt
+++ b/docs/formats/brstm.bt
@@ -5,16 +5,16 @@
 //   Authors: Alex Barney
 //   Version: 1.0
 //   Purpose: Parse BRSTM audio files
-//   Category: Audio
-//   File Mask: *.brstm
-//   ID Bytes: 52 53 54 4D //RSTM
+//  Category: Audio
+// File Mask: *.brstm
+//  ID Bytes: 52 53 54 4D //RSTM
 //   History: 
 //   1.0   Initial Release
 //------------------------------------------------
 
 //Change this variable to display info
 //on each ADPCM frame
-const int detailedData = 0;
+const int detailedData = 1;
 
 typedef char ID[4];
 struct RSTMHeader
@@ -33,7 +33,6 @@ struct RSTMHeader
     int32 AdpcChunkSize;
     int32 DataChunkOffset;
     int32 DataChunkSize;
-    //byte Padding[HeaderSize - FTell() - base];
 };
 
 enum <byte> AudioCodec
@@ -49,17 +48,16 @@ enum <byte> TrackType
     Long  = 1
 };
 
-struct TrackOffset
+struct Pointer
 {
-    byte Marker;
-    TrackType Type;
+    int16 Marker <format=hex>;
     int16 Padding;
     int32 Offset;
 };
 
-struct Track(TrackType type)
+struct Track(int16 type)
 {
-    if (type == Long)
+    if (type == 0x101)
     {
         byte Volume;
         byte Panning;
@@ -72,17 +70,8 @@ struct Track(TrackType type)
     byte Padding;
 };
 
-struct ChannelOffset
+struct AdpcmChannel
 {
-    int32 Marker <format=hex>;
-    int32 Offset;
-};
-
-struct AdpcmChannel (int32 base)
-{
-    int32 Marker <format=hex>;
-    int32 Offset;
-    FSeek(base + Offset);
     SetBackColor(cSilver);
     uint16 Coefficients[16];
     SetBackColor(cAqua);
@@ -93,12 +82,6 @@ struct AdpcmChannel (int32 base)
     int16 LoopPredictorScale <format=hex>;
     int16 LoopHistory1;
     int16 LoopHistory2;
-};
-
-struct PcmChannel
-{
-    int32 Marker <format=hex>;
-    int32 Padding;
 };
 
 struct HEADChunk1
@@ -130,12 +113,12 @@ struct HEADChunk2 (int32 base)
     local int i;
     for( i = 0; i < TrackCount; i++ )
     {
-        TrackOffset Offsets;
+        Pointer pTracks;
     }
     for( i = 0; i < TrackCount; i++ )
     {
-        FSeek(base + Offsets[i].Offset);
-        Track track(Offsets[i].Type);
+        FSeek(base + pTracks[i].Offset);
+        Track track(pTracks[i].Marker);
     }
 };
 
@@ -146,19 +129,20 @@ struct HEADChunk3 (int32 base, AudioCodec codec)
     local int i;
     for( i = 0; i < ChannelCount; i++ )
     {
-        ChannelOffset Offsets;
+        Pointer ppChannels;
     }
+
     for( i = 0; i < ChannelCount; i++ )
     {
-        FSeek(base + Offsets[i].Offset);
-        if (codec == GcAdpcm)
-        {
-            AdpcmChannel Channel(base);
-        }
-        else if (codec == PCM_16Bit)
-        {
-            PcmChannel Channel;
-        }
+        FSeek(base + ppChannels[i].Offset);
+        Pointer pChannels;
+    }
+
+    for( i = 0; i < ChannelCount; i++ )
+    {
+        if(pChannels[i].Offset == 0) {continue;}
+        FSeek(base + pChannels[i].Offset);
+        AdpcmChannel Channel;
     }
 };
 
@@ -167,23 +151,20 @@ struct HEADChunk
     ID HeadId;
     int32 Size;
     local int32 base = FTell();
-    int32 Marker1 <format=hex>;
-    int32 Chunk1Offset;
-    int32 Marker2 <format=hex>;
-    int32 Chunk2Offset;
-    int32 Marker3 <format=hex>;
-    int32 Chunk3Offset;
+    Pointer Pointer1;
+    Pointer Pointer2;
+    Pointer Pointer3;
     
     SetBackColor(cLtBlue);
-    FSeek(base + Chunk1Offset);
+    FSeek(base + Pointer1.Offset);
     HEADChunk1 Chunk1;
 
     SetBackColor(cLtGreen);
-    FSeek(base + Chunk2Offset);
+    FSeek(base + Pointer2.Offset);
     HEADChunk2 Chunk2(base);
 
     SetBackColor(cAqua);
-    FSeek(base + Chunk3Offset);
+    FSeek(base + Pointer3.Offset);
     HEADChunk3 Chunk3(base, Chunk1.Codec);
 };
 
@@ -207,7 +188,7 @@ struct ADPCChunk (int32 channelCount)
     local int32 entrySize = channelCount * 4; 
     ID AdpcId;
     int32 Size;
-    local int32 entryCount = Size / entrySize; 
+    local int32 entryCount = (Size - 8) / entrySize; 
     local int32 i;
     for( i = 0; i < entryCount; i++ )
     {
@@ -225,37 +206,34 @@ typedef struct
     }
 } AdpcmFrame <size=8> ;
 
-struct Block(int32 size, AudioCodec codec)
+struct Channel(int32 size, int32 padding, AudioCodec codec)
 {
     if (codec == GcAdpcm && detailedData)
     {
-        local int32 frameCount = size / 8;
+        local int32 frameCount = (size + 7) / 8;
         local int32 j;
         for( j = 0; j < frameCount; j++ )
         {
             AdpcmFrame Frame;
         }
+        if (padding / 8 * 8 > 0)
+            byte Padding[padding / 8 * 8];
     }
     else
     {
-        byte Audio[size];
+        byte Data[size];
+        if (padding)
+            byte Padding[padding];
     }
 };
 
-struct Channel(int32 num, HEADChunk1 &head)
+struct Block(int32 count, int32 size, int32 padding, AudioCodec codec)
 {
-    local int32 fullBlocks = head.BlockCount - 1;
-    FSeek(head.AudioDataOffset + head.BlockSizeBytes * num);
-
-    local int32 i;
-    for (i = 0; i < fullBlocks; i++)
+    local int i;
+    for(i = 0; i < count; i++)
     {
-        FSeek(head.AudioDataOffset + (i * head.BlockSizeBytes * head.ChannelCount) + head.BlockSizeBytes * num);
-        Block block(head.BlockSizeBytes, head.Codec);
+        Channel Channels(size, padding, codec);
     }
-    
-    FSeek(head.AudioDataOffset + (fullBlocks * head.BlockSizeBytes * head.ChannelCount) + head.FinalBlockSizeBytesWithPadding * num);
-    Block block(head.FinalBlockSizeBytesWithoutPadding, head.Codec);
 };
 
 struct DATAChunk (HEADChunk1 &head)
@@ -268,13 +246,25 @@ struct DATAChunk (HEADChunk1 &head)
     FSeek(head.AudioDataOffset);
 
     local int32 i;
-    for (i = 0; i < head.ChannelCount; i++)
+    for (i = 0; i < head.BlockCount - 1; i++)
     {
-        Channel Channels(i, head);        
+        Block Blocks(head.ChannelCount, head.BlockSizeBytes, 0, head.Codec);
     }
+
+    local int padding = head.FinalBlockSizeBytesWithPadding - head.FinalBlockSizeBytesWithoutPadding;
+    Block Blocks(head.ChannelCount, head.FinalBlockSizeBytesWithoutPadding, padding, head.Codec);
 };
 
 BigEndian();
+switch(ReadUShort(4))
+{
+    case 0xFEFF: break;
+    case 0xFFFE: 
+        LittleEndian();
+        break;
+    default: Exit(1);
+}
+
 SetBackColor(cLtGray);
 RSTMHeader Rstm;
 

--- a/src/VGAudio.Cli/ContainerTypes.cs
+++ b/src/VGAudio.Cli/ContainerTypes.cs
@@ -25,7 +25,7 @@ namespace VGAudio.Cli
 
     internal class ContainerType
     {
-        public ContainerType(IEnumerable<string> names, Func<IAudioReader> getReader, Func<IAudioWriter> getWriter, Func<Options, IConfiguration> getConfiguration)
+        public ContainerType(IEnumerable<string> names, Func<IAudioReader> getReader, Func<IAudioWriter> getWriter, Func<Options, IConfiguration, IConfiguration> getConfiguration)
         {
             Names = names;
             GetReader = getReader;
@@ -36,6 +36,6 @@ namespace VGAudio.Cli
         public IEnumerable<string> Names { get; }
         public Func<IAudioReader> GetReader { get; }
         public Func<IAudioWriter> GetWriter { get; }
-        public Func<Options, IConfiguration> GetConfiguration { get; }
+        public Func<Options, IConfiguration, IConfiguration> GetConfiguration { get; }
     }
 }

--- a/src/VGAudio.Cli/Convert.cs
+++ b/src/VGAudio.Cli/Convert.cs
@@ -92,7 +92,7 @@ namespace VGAudio.Cli
             }
             OutType = type;
 
-            Configuration = OutType.GetConfiguration(options);
+            Configuration = OutType.GetConfiguration(options, Configuration);
         }
     }
 }

--- a/src/VGAudio.Cli/CreateConfiguration.cs
+++ b/src/VGAudio.Cli/CreateConfiguration.cs
@@ -2,15 +2,16 @@
 using VGAudio.Containers;
 using VGAudio.Containers.Bxstm;
 using VGAudio.Containers.Dsp;
+using VGAudio.Containers.Idsp;
 using VGAudio.Containers.Wave;
 
 namespace VGAudio.Cli
 {
     internal static class CreateConfiguration
     {
-        public static IConfiguration Wave(Options options)
+        public static IConfiguration Wave(Options options, IConfiguration inConfig = null)
         {
-            var config = new WaveConfiguration();
+            var config = inConfig as WaveConfiguration ?? new WaveConfiguration();
 
             switch (options.OutFormat)
             {
@@ -27,9 +28,9 @@ namespace VGAudio.Cli
             return config;
         }
 
-        public static IConfiguration Dsp(Options options)
+        public static IConfiguration Dsp(Options options, IConfiguration inConfig = null)
         {
-            var config = new DspConfiguration();
+            var config = inConfig as DspConfiguration ?? new DspConfiguration();
 
             switch (options.OutFormat)
             {
@@ -42,9 +43,9 @@ namespace VGAudio.Cli
             return config;
         }
 
-        public static IConfiguration Idsp(Options options)
+        public static IConfiguration Idsp(Options options, IConfiguration inConfig = null)
         {
-            var config = new DspConfiguration();
+            var config = inConfig as IdspConfiguration ?? new IdspConfiguration();
 
             switch (options.OutFormat)
             {
@@ -57,9 +58,9 @@ namespace VGAudio.Cli
             return config;
         }
 
-        public static IConfiguration Brstm(Options options)
+        public static IConfiguration Brstm(Options options, IConfiguration inConfig = null)
         {
-            var config = new BrstmConfiguration();
+            var config = inConfig as BrstmConfiguration ?? new BrstmConfiguration();
 
             switch (options.OutFormat)
             {
@@ -77,31 +78,41 @@ namespace VGAudio.Cli
             return config;
         }
 
-        public static IConfiguration Bcstm(Options options)
+        public static IConfiguration Bcstm(Options options, IConfiguration inConfig = null)
         {
-            var config = new DspConfiguration();
+            var config = inConfig as BcstmConfiguration ?? new BcstmConfiguration();
 
             switch (options.OutFormat)
             {
+                case AudioFormat.GcAdpcm:
+                    config.Codec = BxstmCodec.Adpcm;
+                    break;
                 case AudioFormat.Pcm16:
-                    throw new InvalidDataException("Can't use format PCM16 with BCSTM files");
+                    config.Codec = BxstmCodec.Pcm16Bit;
+                    break;
                 case AudioFormat.Pcm8:
-                    throw new InvalidDataException("Can't use format PCM8 with BCSTM files");
+                    config.Codec = BxstmCodec.Pcm8Bit;
+                    break;
             }
 
             return config;
         }
 
-        public static IConfiguration Bfstm(Options options)
+        public static IConfiguration Bfstm(Options options, IConfiguration inConfig = null)
         {
-            var config = new DspConfiguration();
+            var config = inConfig as BfstmConfiguration ?? new BfstmConfiguration();
 
             switch (options.OutFormat)
             {
+                case AudioFormat.GcAdpcm:
+                    config.Codec = BxstmCodec.Adpcm;
+                    break;
                 case AudioFormat.Pcm16:
-                    throw new InvalidDataException("Can't use format PCM16 with BFSTM files");
+                    config.Codec = BxstmCodec.Pcm16Bit;
+                    break;
                 case AudioFormat.Pcm8:
-                    throw new InvalidDataException("Can't use format PCM8 with BFSTM files");
+                    config.Codec = BxstmCodec.Pcm8Bit;
+                    break;
             }
 
             return config;

--- a/src/VGAudio.Tests/Containers/BcstmTests.cs
+++ b/src/VGAudio.Tests/Containers/BcstmTests.cs
@@ -1,4 +1,5 @@
 ﻿using VGAudio.Containers;
+using VGAudio.Containers.Bxstm;
 using VGAudio.Formats;
 using Xunit;
 
@@ -15,6 +16,30 @@ namespace VGAudio.Tests.Containers
             GcAdpcmFormat audio = GenerateAudio.GenerateAdpcmSineWave(BuildParseTestOptions.Samples, numChannels, BuildParseTestOptions.SampleRate);
 
             BuildParseTests.BuildParseCompareAudio(audio, new BcstmWriter(), new BcstmReader());
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(8)]
+        public void BcstmBuildAndParseEqualPcm16(int numChannels)
+        {
+            Pcm16Format audio = GenerateAudio.GeneratePcmSineWave(BuildParseTestOptions.Samples, numChannels, BuildParseTestOptions.SampleRate);
+            var writer = new BcstmWriter { Configuration = { Codec = BxstmCodec.Pcm16Bit } };
+
+            BuildParseTests.BuildParseCompareAudio(audio, writer, new BcstmReader());
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(8)]
+        public void BcstmBuildAndParseEqualPcm8(int numChannels)
+        {
+            Pcm8SignedFormat audio = GenerateAudio.GeneratePcm8SignedSineWave(BuildParseTestOptions.Samples, numChannels, BuildParseTestOptions.SampleRate);
+            var writer = new BcstmWriter { Configuration = { Codec = BxstmCodec.Pcm8Bit } };
+
+            BuildParseTests.BuildParseCompareAudio(audio, writer, new BcstmReader());
         }
     }
 }

--- a/src/VGAudio.Tests/Containers/BfstmTests.cs
+++ b/src/VGAudio.Tests/Containers/BfstmTests.cs
@@ -1,4 +1,5 @@
 ﻿using VGAudio.Containers;
+using VGAudio.Containers.Bxstm;
 using VGAudio.Formats;
 using Xunit;
 
@@ -15,6 +16,30 @@ namespace VGAudio.Tests.Containers
             GcAdpcmFormat audio = GenerateAudio.GenerateAdpcmSineWave(BuildParseTestOptions.Samples, numChannels, BuildParseTestOptions.SampleRate);
 
             BuildParseTests.BuildParseCompareAudio(audio, new BfstmWriter(), new BfstmReader());
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(8)]
+        public void BfstmBuildAndParseEqualPcm16(int numChannels)
+        {
+            Pcm16Format audio = GenerateAudio.GeneratePcmSineWave(BuildParseTestOptions.Samples, numChannels, BuildParseTestOptions.SampleRate);
+            var writer = new BfstmWriter { Configuration = { Codec = BxstmCodec.Pcm16Bit } };
+
+            BuildParseTests.BuildParseCompareAudio(audio, writer, new BfstmReader());
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(8)]
+        public void BfstmBuildAndParseEqualPcm8(int numChannels)
+        {
+            Pcm8SignedFormat audio = GenerateAudio.GeneratePcm8SignedSineWave(BuildParseTestOptions.Samples, numChannels, BuildParseTestOptions.SampleRate);
+            var writer = new BfstmWriter { Configuration = { Codec = BxstmCodec.Pcm8Bit } };
+
+            BuildParseTests.BuildParseCompareAudio(audio, writer, new BfstmReader());
         }
     }
 }

--- a/src/VGAudio/Containers/BcstmReader.cs
+++ b/src/VGAudio/Containers/BcstmReader.cs
@@ -18,13 +18,16 @@ namespace VGAudio.Containers
 
         protected override BcstmConfiguration GetConfiguration(BcstmStructure structure)
         {
-            return new BcstmConfiguration
+            var configuration = new BcstmConfiguration();
+            if (structure.Codec == BxstmCodec.Adpcm)
             {
-                SamplesPerInterleave = structure.SamplesPerInterleave,
-                SamplesPerSeekTableEntry = structure.SamplesPerSeekTableEntry,
-                IncludeTrackInformation = structure.IncludeTracks,
-                InfoPart1Extra = structure.InfoPart1Extra
-            };
+                configuration.SamplesPerSeekTableEntry = structure.SamplesPerSeekTableEntry;
+            }
+            configuration.Codec = structure.Codec;
+            configuration.SamplesPerInterleave = structure.SamplesPerInterleave;
+            configuration.IncludeTrackInformation = structure.IncludeTracks;
+            configuration.InfoPart1Extra = structure.InfoPart1Extra;
+            return configuration;
         }
     }
 }

--- a/src/VGAudio/Containers/BcstmReader.cs
+++ b/src/VGAudio/Containers/BcstmReader.cs
@@ -24,6 +24,7 @@ namespace VGAudio.Containers
                 configuration.SamplesPerSeekTableEntry = structure.SamplesPerSeekTableEntry;
             }
             configuration.Codec = structure.Codec;
+            configuration.Endianness = structure.Endianness;
             configuration.SamplesPerInterleave = structure.SamplesPerInterleave;
             configuration.IncludeTrackInformation = structure.IncludeTracks;
             configuration.InfoPart1Extra = structure.InfoPart1Extra;

--- a/src/VGAudio/Containers/BfstmReader.cs
+++ b/src/VGAudio/Containers/BfstmReader.cs
@@ -24,6 +24,7 @@ namespace VGAudio.Containers
                 configuration.SamplesPerSeekTableEntry = structure.SamplesPerSeekTableEntry;
             }
             configuration.Codec = structure.Codec;
+            configuration.Endianness = structure.Endianness;
             configuration.SamplesPerInterleave = structure.SamplesPerInterleave;
             configuration.IncludeUnalignedLoopPoints = structure.Version == 4;
             return configuration;

--- a/src/VGAudio/Containers/BfstmReader.cs
+++ b/src/VGAudio/Containers/BfstmReader.cs
@@ -18,12 +18,15 @@ namespace VGAudio.Containers
 
         protected override BfstmConfiguration GetConfiguration(BfstmStructure structure)
         {
-            return new BfstmConfiguration
+            var configuration = new BfstmConfiguration();
+            if (structure.Codec == BxstmCodec.Adpcm)
             {
-                SamplesPerInterleave = structure.SamplesPerInterleave,
-                SamplesPerSeekTableEntry = structure.SamplesPerSeekTableEntry,
-                IncludeUnalignedLoopPoints = structure.Version == 4
-            };
+                configuration.SamplesPerSeekTableEntry = structure.SamplesPerSeekTableEntry;
+            }
+            configuration.Codec = structure.Codec;
+            configuration.SamplesPerInterleave = structure.SamplesPerInterleave;
+            configuration.IncludeUnalignedLoopPoints = structure.Version == 4;
+            return configuration;
         }
     }
 }

--- a/src/VGAudio/Containers/Bxstm/BxstmConfiguration.cs
+++ b/src/VGAudio/Containers/Bxstm/BxstmConfiguration.cs
@@ -13,7 +13,7 @@ namespace VGAudio.Containers.Bxstm
         private const int DefaultInterleave = 0x2000;
         private int _loopPointAlignment = Default;
         private int _samplesPerInterleave = Default;
-        private int _samplesPerSeekTableEntry = 0x3800;
+        private int _samplesPerSeekTableEntry = Default;
 
         /// <summary>
         /// If <c>true</c>, rebuilds the seek table when building the file.
@@ -67,7 +67,7 @@ namespace VGAudio.Containers.Bxstm
         /// value is less than 2.</exception>
         public int SamplesPerSeekTableEntry
         {
-            get => _samplesPerSeekTableEntry;
+            get => _samplesPerSeekTableEntry != Default ? _samplesPerSeekTableEntry : BytesToSamples(DefaultInterleave, Codec);
             set
             {
                 if (value < 2)

--- a/src/VGAudio/Containers/Bxstm/BxstmConfiguration.cs
+++ b/src/VGAudio/Containers/Bxstm/BxstmConfiguration.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using VGAudio.Utilities;
 using static VGAudio.Containers.Bxstm.Common;
 using static VGAudio.Formats.GcAdpcm.GcAdpcmHelpers;
 
@@ -91,5 +92,6 @@ namespace VGAudio.Containers.Bxstm
         }
 
         public BxstmCodec Codec { get; set; } = BxstmCodec.Adpcm;
+        public Endianness? Endianness { get; set; }
     }
 }

--- a/src/VGAudio/Containers/Bxstm/BxstmStructure.cs
+++ b/src/VGAudio/Containers/Bxstm/BxstmStructure.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using VGAudio.Formats;
+using VGAudio.Utilities;
 
 namespace VGAudio.Containers.Bxstm
 {
@@ -9,6 +10,7 @@ namespace VGAudio.Containers.Bxstm
         /// The size of the entire file.
         /// </summary>
         public int FileSize { get; set; }
+        public Endianness Endianness { get; set; }
         /// <summary>
         /// The version listed in the header.
         /// </summary>


### PR DESCRIPTION
Add 8-bit and 16-bit PCM read and write support for both BFSTM and BCSTM files.
Add support for both big-endian and little-endian BFSTM and BCSTM files.