### PR TITLE
Fix deinterleave and interleave bugs

### DIFF
--- a/src/VGAudio.Tests/Helpers/DeinterleaveTests.cs
+++ b/src/VGAudio.Tests/Helpers/DeinterleaveTests.cs
@@ -23,6 +23,12 @@ namespace VGAudio.Tests.Helpers
             new byte[] { 08, 09, 10, 11, 12, 13 }
         };
 
+        //Tests truncating output to multiple blocks shorter than the input
+        private static byte[][] Deinterleaved26Size4Count2Length6 { get; } = {
+            new byte[] { 00, 01, 02, 03, 08, 09 },
+            new byte[] { 04, 05, 06, 07, 12, 13 }
+        };
+
         //Standard test
         private static byte[][] Deinterleaved16Size4Count2 { get; } = {
             new byte[] { 00, 01, 02, 03, 08, 09, 10, 11 },
@@ -74,12 +80,22 @@ namespace VGAudio.Tests.Helpers
             new byte[] { 08, 09, 14 }
         };
 
+        //Tests shortened last input and output blocks and truncated output
+        private static byte[][] Deinterleaved10Size2Count5Length1 { get; } = {
+            new byte[] { 00 },
+            new byte[] { 02 },
+            new byte[] { 04 },
+            new byte[] { 06 },
+            new byte[] { 08 }
+        };
+
         private static IEnumerable<object[]> ArrayData()
         {
             return new[]
             {
                 new object[] {Interleaved(16), Deinterleaved16Size8Count2, 8, 2, -1 },
                 new object[] {Interleaved(16), Deinterleaved16Size8Count2Length6, 8, 2, 6 },
+                new object[] {Interleaved(26), Deinterleaved26Size4Count2Length6, 4, 2, 6 },
                 new object[] {Interleaved(16), Deinterleaved16Size4Count2, 4, 2, -1 },
                 new object[] {Interleaved(16), Deinterleaved16Size4Count4, 4, 4, -1},
                 new object[] {Interleaved(16), Deinterleaved16Size8Count4, 8, 4, -1},
@@ -87,6 +103,7 @@ namespace VGAudio.Tests.Helpers
                 new object[] {Interleaved(12), Deinterleaved12Size2Count4Length6, 2, 4, 6},
                 new object[] {Interleaved(15), Deinterleaved15Size2Count5Length2, 2, 5, 2},
                 new object[] {Interleaved(15), Deinterleaved15Size2Count5Length3, 2, 5, 3},
+                new object[] {Interleaved(10), Deinterleaved10Size2Count5Length1, 2, 5, 1},
                 new object[] {Interleaved(16), new[] { Interleaved(16) }, 8, 1, -1 }
             };
         }

--- a/src/VGAudio.Tests/Helpers/InterleaveTests.cs
+++ b/src/VGAudio.Tests/Helpers/InterleaveTests.cs
@@ -42,6 +42,14 @@ namespace VGAudio.Tests.Helpers
             new byte[] { 12, 13, 14, 15, 00, 00 }
         };
 
+        //Tests much longer input than output
+        private static byte[][] Deinterleaved20Size4Out5 { get; } = {
+            new byte[] { 00, 01, 02, 03, 16, 00, 00, 00, 00, 00 },
+            new byte[] { 04, 05, 06, 07, 17, 00, 00, 00, 00, 00 },
+            new byte[] { 08, 09, 10, 11, 18, 00, 00, 00, 00, 00 },
+            new byte[] { 12, 13, 14, 15, 19, 00, 00, 00, 00, 00 }
+        };
+
         //Tests shorter input than output
         private static byte[][] Deinterleaved16Size8Length6 { get; } = {
             new byte[] { 00, 01, 02, 03, 04, 05 },
@@ -51,6 +59,19 @@ namespace VGAudio.Tests.Helpers
         private static byte[] Interleaved16Size8Length6 { get; } = {
             00, 01, 02, 03, 04, 05, 00, 00,
             08, 09, 10, 11, 12, 13, 00, 00
+        };
+
+        //Tests much shorter input than output
+        private static byte[][] Deinterleaved26Size4Length6 { get; } = {
+            new byte[] { 00, 01, 02, 03, 08, 09 },
+            new byte[] { 04, 05, 06, 07, 12, 13 }
+        };
+
+        private static byte[] Interleaved26Size4Length6 { get; } = {
+            00, 01, 02, 03, 04, 05, 06, 07,
+            08, 09, 00, 00, 12, 13, 00, 00,
+            00, 00, 00, 00, 00, 00, 00, 00,
+            00, 00
         };
 
         //Tests shortened last block
@@ -70,7 +91,9 @@ namespace VGAudio.Tests.Helpers
                 new object[] { Deinterleaved16Size4Count2, Interleaved(16), 4, -1},
                 new object[] { Deinterleaved16Size4Count4, Interleaved(16), 4, -1},
                 new object[] { Deinterleaved16Size4Out4, Interleaved(16), 4, 4},
+                new object[] { Deinterleaved20Size4Out5, Interleaved(20), 4, 5},
                 new object[] { Deinterleaved16Size8Length6, Interleaved16Size8Length6, 8, 8},
+                new object[] { Deinterleaved26Size4Length6, Interleaved26Size4Length6, 4, 13},
                 new object[] { Deinterleaved15Size2Count5Length3, Interleaved(15), 2, -1},
                 //Tests shorter output than input
                 new object[] { Deinterleaved15Size2Count5Length3, Interleaved(10), 2, 2}


### PR DESCRIPTION
The deinterleave and interleave functions would fail when the input was over a block larger than the output. Add tests and fix.

This doesn't usually happen, but BCSTM files tend to contain a little extra audio, and the issue was caught when reading a BCSTM where the extra audio data spilled over into the next interleave block.