### PR TITLE
Improve ADPCM encoder accuracy

### DIFF
--- a/src/VGAudio/Codecs/GcAdpcmEncoder.cs
+++ b/src/VGAudio/Codecs/GcAdpcmEncoder.cs
@@ -492,9 +492,10 @@ namespace VGAudio.Codecs
                     /* Evaluate from real sample */
                     v2 = (pcmInOut[s + 2] << 11) - v1;
                     /* Round to nearest sample */
+                    // The official encoder does the casting this way, so match that behavior
                     v3 = (v2 > 0)
-                        ? (int)((double)v2 / (1 << scale) / 2048 + 0.4999999f)
-                        : (int)((double)v2 / (1 << scale) / 2048 - 0.4999999f);
+                        ? (int)((double)((float)v2 / (1 << scale) / 2048) + 0.4999999f)
+                        : (int)((double)((float)v2 / (1 << scale) / 2048) - 0.4999999f);
 
                     /* Clamp sample and set index */
                     if (v3 < -8)


### PR DESCRIPTION
The official implementation does some weird things with floating point types. This will cause slight rounding differences in very rare cases. I found three ADPCM frames that trigger this behavior out of over 5 billion total ADPCM frames.

Now the encoder is 100% accurate to the official implementation, from my testing