### PR TITLE
Cleanup GC ADPCM encoder

### DIFF
--- a/docs/formats/bfstm.bt
+++ b/docs/formats/bfstm.bt
@@ -12,101 +12,144 @@
 //   1.0   Initial Release
 //------------------------------------------------
 
+struct Reference;
+struct ReferenceTable;
+struct InfoBlock;
+struct SeekBlock;
+struct RegionBlock;
+struct DataBlock;
+struct StreamInfo;
+struct ChannelInfo;
+struct AdpcmChannelInfo;
+struct TrackInfo;
+
 typedef char ID[4];
-struct Header
+
+typedef enum <int16> 
 {
-    ID RstmId;
-    int16 BOM;
-    int16 HeaderSize;
-    int32 Version;
-    int32 FileSize;
-    int16 ChunkCount;
-    int16 Padding;
-    
-    local int i;
-    for( i = 0; i < ChunkCount; i++)
-    {
-        switch(ReadShort())
-        {
-            case 0x4000:
-                int16 InfoMarker <format=hex>;
-                FSkip(2);
-                int32 InfoChunkOffset;
-                int32 InfoChunkSize;
-                break;
-            case 0x4001:
-                int16 SeekMarker <format=hex>;
-                FSkip(2);
-                int32 SeekChunkOffset;
-                int32 SeekChunkSize;
-                break;
-            case 0x4002:
-                int16 DataMarker <format=hex>;
-                FSkip(2);
-                int32 DataChunkOffset;
-                int32 DataChunkSize;
-                break;
-            case 0x4003:
-                int16 RegnMarker <format=hex>;
-                FSkip(2);
-                int32 RegnChunkOffset;
-                int32 RegnChunkSize;
-                break;
-            case 0x4004:
-                int16 PdatMarker <format=hex>;
-                FSkip(2);
-                int32 PdatChunkOffset;
-                int32 PdatChunkSize;
-                break;
-        }
-    }
-};
+    ByteTableType = 0x0100,
+    ReferenceTableType = 0x0101,
+    DspAdpcmInfoType = 0x0300,
+    ImaAdpcmInfoType = 0x0301,
+    SampleDataType = 0x1f00,
+    InfoBlockType = 0x4000,
+    SeekBlockType = 0x4001,
+    DataBlockType = 0x4002,
+    RegionBlockType = 0x4003,
+    PdatBlockType = 0x4004,
+    StreamInfoType = 0x4100,
+    TrackInfoType = 0x4101,
+    ChannelInfoType = 0x4102,
+} Type <format=hex>;
 
 enum <byte> AudioCodec
 {
     PCM_8Bit   = 0,
     PCM_16Bit  = 1,
-    GcAdpcm    = 2
+    GcAdpcm    = 2,
+    ImaAdpcm   = 3,
 };
 
-struct Pointer
+struct Reference(int baseOffset)
 {
-    int16 Marker <format=hex>;
+    Type type;
     int16 Padding;
     int32 Offset;
+    
+    local int32 original = FTell();
+    FSeek(baseOffset + Offset);
+
+    switch(type)
+    {
+        case ReferenceTableType:
+            ReferenceTable reference;
+            break;
+        case StreamInfoType:
+            StreamInfo streamInfo;
+            break;
+        case ChannelInfoType:
+            ChannelInfo channelInfo;
+            break;
+        case DspAdpcmInfoType:
+            AdpcmChannelInfo adpcmChannelInfo;
+            break;
+        case TrackInfoType:
+            TrackInfo track;
+            break;
+    }
+
+    FSeek(original);
 };
 
-struct Track
-{
-    byte Volume;
-    byte Panning;
-    int16 Unknown1;
-    int32 Unknown2;
-    int32 Unknown3;
-    int32 ChannelCount;
-    byte LeftChannelId;
-    byte RightChannelId;
+struct SizedReference
+{    
+    Type type;
     int16 Padding;
+    int32 Offset;
+    int32 Size;
+
+    local int32 original = FTell();
+    FSeek(Offset);
+
+    switch(type)
+    {
+        case InfoBlockType:
+            InfoBlock infoBlock;
+            break;
+        case SeekBlockType:
+            SeekBlock seekBlock;
+            break;
+        case DataBlockType:
+            DataBlock dataBlock(Blocks[GetBlockIndex(InfoBlockType)].infoBlock.streamInfo.streamInfo);
+            break;
+        case RegionBlockType:
+            RegionBlock regionBlock;
+            break;
+    }
+
+    FSeek(original);
 };
 
-struct AdpcmChannel
+struct ReferenceTable
 {
-    uint16 Coefficients[16];
-    int16 Gain;
-    int16 InitialPredictorScale <format=hex>;
-    int16 History1;
-    int16 History2;
-    int16 LoopPredictorScale <format=hex>;
-    int16 LoopHistory1;
-    int16 LoopHistory2;
+    local int32 base = FTell();
+    local int32 i = 0;
+    int32 Count;
+    for(i = 0; i < Count; i++)
+    {
+        Reference Entries(base);
+    }    
 };
 
-struct INFOChunk1(Header &head)
+int GetBlockIndex(Type type)
+{
+    local int i;
+    for(i = 0; i < BlockCount; i++)
+    {
+        if(Blocks[i].type == type)
+        {
+            return i;
+        }
+    }
+    return -1;
+}
+
+struct InfoBlock
+{    
+    ID InfoId;
+    int32 Size;
+    local int32 base = FTell();
+    Reference streamInfo(base);
+    Reference TrackInfoTable(base);
+    Reference ChannelInfoTable(base);
+};
+
+struct StreamInfo
 {
     AudioCodec Codec;
     byte Loops;
     byte ChannelCount;
-    byte SectionCount;
+    byte RegionCount;
     int32 SampleRate;
     int32 LoopStart;
     int32 SampleCount;    
@@ -119,112 +162,51 @@ struct INFOChunk1(Header &head)
     int32 BytesPerSeekTableEntry;
     int32 SamplesPerSeekTableEntry;
 
-    Pointer pAudioData;
+    Reference pAudioData(0);
     
     if(ReadShort() == 0x100)
     {
-        int16 ExtraMarker <format=hex>;
-        byte Extra[10];
+        int16 REGNEntrySize;
+        int16 Padding;
+        Reference pREGNData(0);
     }
 
-    if(head.Version >> 16 == 4)
+    if(Version >> 16 == 4)
     {
         int32 UnalignedLoopStart;
         int32 UnalignedSampleCount; 
     }
 };
 
-struct INFOChunk2
+struct TrackInfo
 {
     local int32 base = FTell();
-    int32 TrackCount;
-    local int i;
-    for(i = 0; i < TrackCount; i++)
-    {
-        Pointer pTracks;
-    }
-    for(i = 0; i < TrackCount; i++)
-    {
-        FSeek(base + pTracks[i].Offset);
-        Track tracks;
-    }
-};
-
-struct INFOChunk3(AudioCodec codec)
-{
-    local int32 base = FTell();
+    byte Volume;
+    byte Panning;
+    byte SurroundPanning;
+    byte Flags;
+    Reference Table(base);
     int32 ChannelCount;
-    local int i;
-    for(i = 0; i < ChannelCount; i++)
-    {
-        Pointer ppChannels;
-    }
-
-    for( i = 0; i < ChannelCount; i++ )
-    {
-        FSeek(base + ppChannels[i].Offset);
-        Pointer pChannels;
-    }
-
-    for( i = 0; i < ChannelCount; i++ )
-    {
-        if(pChannels[i].Offset == -1) {continue;}
-        FSeek(base + ppChannels[i].Offset + pChannels[i].Offset);
-        AdpcmChannel Channel;
-    }
+    byte LeftChannelId;
+    byte RightChannelId;
+    int16 Padding2;
 };
 
-struct INFOChunk(Header &head)
-{    
-    ID InfoId;
-    int32 Size;
-    local int32 base = FTell();
-    Pointer pChunk1;
-    Pointer pChunk2;
-    Pointer pChunk3;
-    
-    FSeek(base + pChunk1.Offset);
-    INFOChunk1 Chunk1(head);
-
-    if(pChunk2.Offset != -1)
-    {
-        FSeek(base + pChunk2.Offset);
-        INFOChunk2 Chunk2;
-    }
-
-    FSeek(base + pChunk3.Offset);
-    INFOChunk3 Chunk3(Chunk1.Codec);
-};
-
-struct REGNEntryChannel
-{
-    int16 PredScale;
-    int16 Unknown1;
-    int16 Unknown2;
-};
-
-struct REGNEntry (int32 channelCount)
-{
-    int32 StartSample;
-    int32 EndSample;
-    local int32 i;
-    for( i = 0; i < channelCount; i++ )
-    {
-        REGNEntryChannel Channel;
-    }
-};
-
-struct REGNChunk (int32 sectionCount, int32 channelCount)
+struct ChannelInfo
 {
     local int32 base = FTell();
-    ID InfoId;
-    int32 Size;
-    local int32 i;
-    for( i = 0; i < sectionCount; i++ )
-    {
-        FSeek(base + 0x20 + 0x100 * i);
-        REGNEntry Entry(channelCount);
-    }
+    Reference channelInfo(base);
+};
+
+struct AdpcmChannelInfo
+{
+    uint16 Coefficients[16];
+    int16 InitialPredictorScale <format=hex>;
+    int16 History1;
+    int16 History2;
+    int16 LoopPredictorScale <format=hex>;
+    int16 LoopHistory1;
+    int16 LoopHistory2;
 };
 
 struct SeekTableEntryChannel
@@ -233,8 +215,8 @@ struct SeekTableEntryChannel
     int16 History2;
 };
 
-struct SeekTableEntry (int32 channelCount)
-{
+struct SeekTableEntry(int32 channelCount)
+{    
     local int32 i;
     for( i = 0; i < channelCount; i++ )
     {
@@ -242,8 +224,9 @@ struct SeekTableEntry (int32 channelCount)
     }
 };
 
-struct SEEKChunk (int32 channelCount)
-{    
+struct SeekBlock
+{   
+    local int32 channelCount = Blocks[GetBlockIndex(InfoBlockType)].infoBlock.streamInfo.streamInfo.ChannelCount;
     local int32 entrySize = channelCount * 4; 
     ID SeekId;
     int32 Size;
@@ -255,7 +238,34 @@ struct SEEKChunk (int32 channelCount)
     }
 };
 
-struct Channel(int32 size, int32 padding)
+struct LoopContext
+{
+    int16 PredScale;
+    int16 History1;
+    int16 History2;
+};
+
+struct RegionInfo
+{
+    local int32 channelCount = Blocks[GetBlockIndex(InfoBlockType)].infoBlock.streamInfo.streamInfo.ChannelCount;
+    local int32 endAddress = FTell() + 0x100;
+    int32 StartSample;
+    int32 EndSample;
+    LoopContext Channels[channelCount];
+    byte Padding[endAddress - FTell()];
+};
+
+struct RegionBlock
+{    
+    local int32 regionCount = Blocks[GetBlockIndex(InfoBlockType)].infoBlock.streamInfo.streamInfo.RegionCount;
+    local int32 base = FTell();
+    ID RegionId;
+    int32 Size;
+    byte Padding[0x18];
+    RegionInfo Regions[regionCount] <optimize=true>;
+};
+
+struct AudioChannel(int32 size, int32 padding)
 {
     byte Data[size];
     if (padding)
@@ -263,16 +273,16 @@ struct Channel(int32 size, int32 padding)
 };
 
 
-struct Block(int32 count, int32 size, int32 padding)
+struct AudioBlock(int32 count, int32 size, int32 padding)
 {
     local int i;
     for(i = 0; i < count; i++)
     {
-        Channel Channels(size, padding);
+        AudioChannel Channels(size, padding);
     }
 };
 
-struct DATAChunk (INFOChunk1 &head)
+struct DataBlock (StreamInfo &head)
 {    
     ID DataId;
     int32 Size;
@@ -281,11 +291,11 @@ struct DATAChunk (INFOChunk1 &head)
     local int32 i;
     for (i = 0; i < head.BlockCount - 1; i++)
     {
-        Block Blocks(head.ChannelCount, head.BlockSizeBytes, 0);
+        AudioBlock Blocks(head.ChannelCount, head.BlockSizeBytes, 0);
     }
 
     local int padding = head.FinalBlockSizeBytesWithPadding - head.FinalBlockSizeBytesWithoutPadding;
-    Block Blocks(head.ChannelCount, head.FinalBlockSizeBytesWithoutPadding, padding); 
+    AudioBlock Blocks(head.ChannelCount, head.FinalBlockSizeBytesWithoutPadding, padding); 
 };
 
 BigEndian();
@@ -298,28 +308,11 @@ switch(ReadUShort(4))
     default: Exit(1);
 }
 
-Header Head;
-
-if(exists(Head.InfoMarker))
-{
-    FSeek(Head.InfoChunkOffset);
-    INFOChunk Info(Head);
-}
-
-if(exists(Head.SeekMarker))
-{
-    FSeek(Head.SeekChunkOffset);
-    SEEKChunk Seek(Info.Chunk1.ChannelCount);
-}
-
-if(exists(Head.RegnMarker))
-{
-    FSeek(Head.RegnChunkOffset);
-    REGNChunk Regn(Info.Chunk1.SectionCount, Info.Chunk1.ChannelCount);
-}
-
-if(exists(Head.DataMarker))
-{
-    FSeek(Head.DataChunkOffset);
-    DATAChunk Data(Info.Chunk1);
-}
+ID RstmId;
+int16 BOM <format=hex>;
+int16 HeaderSize;
+int32 Version <format=hex>;
+int32 FileSize;
+int16 BlockCount;
+int16 Padding;
+SizedReference Blocks[BlockCount] <optimize=false>;

--- a/docs/formats/dsp.bt
+++ b/docs/formats/dsp.bt
@@ -1,0 +1,91 @@
+//------------------------------------------------
+//--- 010 Editor v8.0 Binary Template
+//
+//      File: dsp.bt
+//   Authors: Alex Barney
+//   Version: 1.0
+//   Purpose: Parse standard Nintendo DSP audio files
+//  Category: Audio
+// File Mask: *.dsp
+//  ID Bytes: 
+//   History: 
+//   1.0   Initial Release
+//------------------------------------------------
+
+uint GetNextMultiple(uint value, uint multiple) 
+{
+    return ((value + multiple - 1) / multiple) * multiple;
+}
+
+uint DivideBy2RoundUp(uint value)
+{
+    return (value / 2) + (value & 1);
+}
+
+struct DspHeader
+{
+    uint32 SampleCount;
+    uint32 NibbleCount;
+    uint32 SampleRate;
+    uint16 LoopFlag;
+    uint16 AudioFormat;
+    uint32 StartAddress;
+    uint32 EndAddress;
+    uint32 CurrentAddress;
+    uint16 Coefficients[16];
+    uint16 Gain;
+    uint16 InitialPredictorScale <format=hex>;
+    uint16 History1;
+    uint16 History2;
+    uint16 LoopPredictorScale <format=hex>;
+    uint16 LoopHistory1;
+    uint16 LoopHistory2;
+    uint16 ChannelCount;
+    uint16 InterleaveSizeFrames;
+    byte Padding[18];
+};
+
+struct Channel(uint dataLength)
+{
+    byte AudioData[dataLength];
+
+    local uint padding = GetNextMultiple(FTell(), 0x10) - FTell();
+    if(padding > 0)
+    {
+        byte Padding[padding];
+    }
+};
+
+struct Block(uint channelCount, uint interleaveSize)
+{
+    local uint i;
+    for(i = 0; i < channelCount; i++)
+    {
+        Channel channel(interleaveSize);
+    }
+};
+
+BigEndian();
+DspHeader Header;
+
+local uint AudioDataLength = DivideBy2RoundUp(Header.NibbleCount);
+if(Header.ChannelCount <= 1)
+{
+    byte AudioData[AudioDataLength];
+    return;
+}
+
+local uint i;
+for(i = 1; i < Header.ChannelCount; i++)
+{
+    DspHeader Header;
+}
+
+local uint BlockSize;
+local uint InterleaveSize = Header.InterleaveSizeFrames * 8;
+while(AudioDataLength > 0)
+{
+    BlockSize = Min(InterleaveSize, AudioDataLength);
+    Block block(Header.ChannelCount, BlockSize);
+    AudioDataLength -= BlockSize;
+} 

--- a/src/VGAudio.Benchmark/AdpcmBenchmarks/EncodeBenchmarks.cs
+++ b/src/VGAudio.Benchmark/AdpcmBenchmarks/EncodeBenchmarks.cs
@@ -15,11 +15,11 @@ namespace VGAudio.Benchmark.AdpcmBenchmarks
         public void Setup()
         {
             _pcm = GenerateAudio.GenerateSineWave((int)(_sampleRate * LengthSeconds), 440, _sampleRate);
-            _coefs = GcAdpcmEncoder.DspCorrelateCoefs(_pcm);
+            _coefs = GcAdpcmCoefficient.CalculateCoefficients(_pcm);
         }
 
-        [Benchmark] public short[] GenerateCoefs() => GcAdpcmEncoder.DspCorrelateCoefs(_pcm);
+        [Benchmark] public short[] GenerateCoefs() => GcAdpcmCoefficient.CalculateCoefficients(_pcm);
         [Benchmark] public byte[] EncodeAdpcm() => GcAdpcmEncoder.EncodeAdpcm(_pcm, _coefs);
-        [Benchmark] public byte[] GenerateCoefsAndEncodeAdpcm() => GcAdpcmEncoder.EncodeAdpcm(_pcm, GcAdpcmEncoder.DspCorrelateCoefs(_pcm));
+        [Benchmark] public byte[] GenerateCoefsAndEncodeAdpcm() => GcAdpcmEncoder.EncodeAdpcm(_pcm, GcAdpcmCoefficient.CalculateCoefficients(_pcm));
     }
 }

--- a/src/VGAudio.Cli/Convert.cs
+++ b/src/VGAudio.Cli/Convert.cs
@@ -33,7 +33,7 @@ namespace VGAudio.Cli
 
         private void ReadFile(AudioFile file)
         {
-            using (var stream = new FileStream(file.Path, FileMode.Open))
+            using (var stream = new FileStream(file.Path, FileMode.Open, FileAccess.Read))
             {
                 ContainerTypes.Containers.TryGetValue(file.Type, out ContainerType type);
 
@@ -50,7 +50,7 @@ namespace VGAudio.Cli
 
         private void WriteFile(string fileName)
         {
-            using (var stream = new FileStream(fileName, FileMode.Create))
+            using (var stream = new FileStream(fileName, FileMode.Create, FileAccess.ReadWrite))
             {
                 OutType.GetWriter().WriteToStream(Audio, stream, Configuration);
             }

--- a/src/VGAudio.Cli/Metadata/Common.cs
+++ b/src/VGAudio.Cli/Metadata/Common.cs
@@ -1,7 +1,4 @@
-﻿using System;
-using VGAudio.Containers.Bxstm;
-
-namespace VGAudio.Cli.Metadata
+﻿namespace VGAudio.Cli.Metadata
 {
     internal class Common
     {
@@ -12,20 +9,5 @@ namespace VGAudio.Cli.Metadata
         public int LoopStart { get; set; }
         public int LoopEnd { get; set; }
         public AudioFormat Format { get; set; }
-
-        public static AudioFormat FromBxstm(BxstmCodec codec)
-        {
-            switch (codec)
-            {
-                case BxstmCodec.Pcm8Bit:
-                    return AudioFormat.Pcm8;
-                case BxstmCodec.Pcm16Bit:
-                    return AudioFormat.Pcm16;
-                case BxstmCodec.Adpcm:
-                    return AudioFormat.GcAdpcm;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(codec), codec, null);
-            }
-        }
     }
 }

--- a/src/VGAudio.Cli/Metadata/Containers/Bxstm.cs
+++ b/src/VGAudio.Cli/Metadata/Containers/Bxstm.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Linq;
 using System.Text;
 using VGAudio.Containers.Bxstm;
@@ -19,7 +20,7 @@ namespace VGAudio.Cli.Metadata.Containers
                 SampleCount = bxstm.SampleCount,
                 SampleRate = bxstm.SampleRate,
                 ChannelCount = bxstm.ChannelCount,
-                Format = Common.FromBxstm(bxstm.Codec),
+                Format = FromBxstm(bxstm.Codec),
                 Looping = bxstm.Looping,
                 LoopStart = bxstm.LoopStart,
                 LoopEnd = bxstm.SampleCount
@@ -46,7 +47,7 @@ namespace VGAudio.Cli.Metadata.Containers
             builder.AppendLine();
 
             builder.AppendLine($"Samples per seek table entry: {bxstm.SamplesPerSeekTableEntry}");
-            
+
             for (int i = 0; i < bxstm.Tracks.Count; i++)
             {
                 builder.AppendLine();
@@ -66,6 +67,21 @@ namespace VGAudio.Cli.Metadata.Containers
             builder.AppendLine($"Right channel ID: {track.ChannelRight}");
             builder.AppendLine($"Volume: 0x{track.Volume:X2}");
             builder.AppendLine($"Panning: 0x{track.Panning:X2}");
+        }
+
+        public static AudioFormat FromBxstm(BxstmCodec codec)
+        {
+            switch (codec)
+            {
+                case BxstmCodec.Pcm8Bit:
+                    return AudioFormat.Pcm8;
+                case BxstmCodec.Pcm16Bit:
+                    return AudioFormat.Pcm16;
+                case BxstmCodec.Adpcm:
+                    return AudioFormat.GcAdpcm;
+                default:
+                    throw new ArgumentOutOfRangeException(nameof(codec), codec, null);
+            }
         }
     }
 }

--- a/src/VGAudio.Cli/Metadata/Containers/GcAdpcm.cs
+++ b/src/VGAudio.Cli/Metadata/Containers/GcAdpcm.cs
@@ -6,17 +6,17 @@ namespace VGAudio.Cli.Metadata.Containers
 {
     internal static class GcAdpcm
     {
-        public static void PrintAdpcmMetadata(IList<GcAdpcmChannelInfo> channels, StringBuilder builder)
+        public static void PrintAdpcmMetadata(IList<GcAdpcmChannelInfo> channels, StringBuilder builder, bool printLoopInfo = true)
         {
             for (int i = 0; i < channels.Count; i++)
             {
                 builder.AppendLine($"\nChannel {i}");
                 builder.AppendLine(new string('-', 40));
-                PrintChannelMetadata(channels[i], builder);
+                PrintChannelMetadata(channels[i], builder, printLoopInfo);
             }
         }
 
-        public static void PrintChannelMetadata(GcAdpcmChannelInfo channel, StringBuilder builder)
+        public static void PrintChannelMetadata(GcAdpcmChannelInfo channel, StringBuilder builder, bool printLoopInfo)
         {
             builder.AppendLine("Coefficients:");
             builder.AppendLine($"{CoefficientsToString(channel.Coefs)}");
@@ -24,6 +24,8 @@ namespace VGAudio.Cli.Metadata.Containers
             builder.AppendLine($"Pred/Scale: 0x{channel.PredScale:X4}");
             builder.AppendLine($"History sample 1 (n-1): 0x{channel.Hist1:X4}");
             builder.AppendLine($"History sample 2 (n-2): 0x{channel.Hist2:X4}");
+            if (!printLoopInfo) return;
+
             builder.AppendLine();
             builder.AppendLine($"Loop Pred/Scale: 0x{channel.LoopPredScale:X4}");
             builder.AppendLine($"Loop History sample 1: 0x{channel.LoopHist1:X4}");

--- a/src/VGAudio.Cli/Metadata/Containers/Hps.cs
+++ b/src/VGAudio.Cli/Metadata/Containers/Hps.cs
@@ -1,0 +1,43 @@
+﻿using System.IO;
+using System.Linq;
+using System.Text;
+using VGAudio.Containers;
+using VGAudio.Containers.Hps;
+using VGAudio.Formats.GcAdpcm;
+
+namespace VGAudio.Cli.Metadata.Containers
+{
+    internal class Hps : MetadataReader
+    {
+        public override Common ToCommon(object structure)
+        {
+            var hps = structure as HpsStructure;
+            if (hps == null) throw new InvalidDataException("Could not parse file metadata.");
+
+            return new Common
+            {
+                SampleCount = hps.SampleCount,
+                SampleRate = hps.SampleRate,
+                ChannelCount = hps.ChannelCount,
+                Format = AudioFormat.GcAdpcm,
+                Looping = hps.Looping,
+                LoopStart = hps.LoopStart,
+                LoopEnd = hps.SampleCount
+            };
+        }
+
+        public override object ReadMetadata(Stream stream) => new HpsReader().ReadMetadata(stream);
+
+        public override void PrintSpecificMetadata(object structure, StringBuilder builder)
+        {
+            var hps = structure as HpsStructure;
+            if (hps == null) throw new InvalidDataException("Could not parse file metadata.");
+
+            builder.AppendLine();
+
+            builder.AppendLine($"Max block size: 0x{hps.Channels.First().MaxBlockSize:X}");
+
+            GcAdpcm.PrintAdpcmMetadata(hps.Channels.Cast<GcAdpcmChannelInfo>().ToList(), builder, printLoopInfo: false);
+        }
+    }
+}

--- a/src/VGAudio.Cli/Metadata/Print.cs
+++ b/src/VGAudio.Cli/Metadata/Print.cs
@@ -60,6 +60,7 @@ namespace VGAudio.Cli.Metadata
             [FileType.Brstm] = new Brstm(),
             [FileType.Bcstm] = new Bcstm(),
             [FileType.Bfstm] = new Bfstm(),
+            [FileType.Hps] = new Hps(),
             [FileType.Genh] = new Genh()
         };
 

--- a/src/VGAudio.Tests/Formats/GcAdpcm/GcAdpcmAlignmentTests.cs
+++ b/src/VGAudio.Tests/Formats/GcAdpcm/GcAdpcmAlignmentTests.cs
@@ -70,7 +70,7 @@ namespace VGAudio.Tests.Formats.GcAdpcm
         {
             int loopEnd = sineCycles * 4 * SamplesPerFrame + loopStart;
             var pcm = GenerateSineWave(GetNextMultiple(loopEnd, SamplesPerFrame), 1, SamplesPerFrame * 4);
-            var coefs = GcAdpcmEncoder.DspCorrelateCoefs(pcm);
+            var coefs = GcAdpcmCoefficient.CalculateCoefficients(pcm);
             var adpcm = GcAdpcmEncoder.EncodeAdpcm(pcm, coefs);
             var alignment = new GcAdpcmAlignment(multiple, loopStart, loopEnd, adpcm, coefs);
             var pcmAligned = GcAdpcmDecoder.Decode(alignment.AdpcmAligned, coefs, alignment.SampleCountAligned);
@@ -98,7 +98,7 @@ namespace VGAudio.Tests.Formats.GcAdpcm
         {
             int loopEnd = sineCycles * 4 * SamplesPerFrame + loopStart;
             var pcm = GenerateSineWave(GetNextMultiple(loopEnd, SamplesPerFrame), 1, SamplesPerFrame * 4);
-            var coefs = GcAdpcmEncoder.DspCorrelateCoefs(pcm);
+            var coefs = GcAdpcmCoefficient.CalculateCoefficients(pcm);
             var adpcm = GcAdpcmEncoder.EncodeAdpcm(pcm, coefs);
             var alignment = new GcAdpcmAlignment(multiple, loopStart, loopEnd, adpcm, coefs);
             var pcmAligned = alignment.PcmAligned;

--- a/src/VGAudio.TestsLong/GcAdpcm/DspToolVGAudio.cs
+++ b/src/VGAudio.TestsLong/GcAdpcm/DspToolVGAudio.cs
@@ -8,7 +8,7 @@ namespace VGAudio.TestsLong.GcAdpcm
         public GcAdpcmChannel EncodeChannel(short[] pcm)
         {
             int sampleCount = pcm.Length;
-            short[] coefs = GcAdpcmEncoder.DspCorrelateCoefs(pcm);
+            short[] coefs = GcAdpcmCoefficient.CalculateCoefficients(pcm);
             byte[] adpcm = GcAdpcmEncoder.EncodeAdpcm(pcm, coefs);
 
             return new GcAdpcmChannel(adpcm, coefs, sampleCount);
@@ -16,7 +16,7 @@ namespace VGAudio.TestsLong.GcAdpcm
 
         public short[] DspCorrelateCoefs(short[] pcm)
         {
-            return GcAdpcmEncoder.DspCorrelateCoefs(pcm);
+            return GcAdpcmCoefficient.CalculateCoefficients(pcm);
         }
 
         public void DspEncodeFrame(short[] pcmInOut, int sampleCount, byte[] adpcmOut, short[] coefsIn)

--- a/src/VGAudio/Codecs/GcAdpcmCoefficient.cs
+++ b/src/VGAudio/Codecs/GcAdpcmCoefficient.cs
@@ -1,0 +1,398 @@
+﻿using System;
+using VGAudio.Utilities;
+using static VGAudio.Formats.GcAdpcm.GcAdpcmHelpers;
+
+namespace VGAudio.Codecs
+{
+    public static class GcAdpcmCoefficient
+    {
+        public static short[] CalculateCoefficients(short[] source)
+        {
+            int frameCount = source.Length.DivideByRoundUp(SamplesPerFrame);
+
+            short[] pcmHistBuffer = new short[28];
+
+            short[] coefs = new short[16];
+
+            double[] vec1 = new double[3];
+            double[] vec2 = new double[3];
+            double[] buffer = new double[3];
+
+            double[][] mtx = new double[3][];
+            for (int i = 0; i < mtx.Length; i++)
+            {
+                mtx[i] = new double[3];
+            }
+
+            int[] vecIdxs = new int[3];
+
+            double[,] records = new double[frameCount * 2, 3];
+
+            int recordCount = 0;
+
+            double[][] vecBest = new double[8][];
+            for (int i = 0; i < vecBest.Length; i++)
+            {
+                vecBest[i] = new double[3];
+            }
+
+            /* Iterate though one frame at a time */
+            for (int sample = 0, remaining = source.Length; sample < source.Length; sample += 14, remaining -= 14)
+            {
+                Array.Clear(pcmHistBuffer, 14, 14);
+                Array.Copy(source, sample, pcmHistBuffer, 14, Math.Min(14, remaining));
+
+                InnerProductMerge(vec1, pcmHistBuffer);
+                if (Math.Abs(vec1[0]) > 10.0)
+                {
+                    OuterProductMerge(mtx, pcmHistBuffer);
+                    if (!AnalyzeRanges(mtx, vecIdxs, buffer))
+                    {
+                        BidirectionalFilter(mtx, vecIdxs, vec1);
+                        if (!QuadraticMerge(vec1))
+                        {
+                            FinishRecord(vec1, records, recordCount);
+                            recordCount++;
+                        }
+                    }
+                }
+
+                Array.Copy(pcmHistBuffer, 14, pcmHistBuffer, 0, 14);
+            }
+
+            vec1[0] = 1.0;
+            vec1[1] = 0.0;
+            vec1[2] = 0.0;
+
+            for (int z = 0; z < recordCount; z++)
+            {
+                MatrixFilter(records, z, vecBest[0], mtx);
+                for (int y = 1; y <= 2; y++)
+                    vec1[y] += vecBest[0][y];
+            }
+            for (int y = 1; y <= 2; y++)
+                vec1[y] /= recordCount;
+
+            MergeFinishRecord(vec1, vecBest[0]);
+
+
+            int exp = 1;
+            for (int w = 0; w < 3;)
+            {
+                vec2[0] = 0.0;
+                vec2[1] = -1.0;
+                vec2[2] = 0.0;
+                for (int i = 0; i < exp; i++)
+                for (int y = 0; y <= 2; y++)
+                    vecBest[exp + i][y] = (0.01 * vec2[y]) + vecBest[i][y];
+                ++w;
+                exp = 1 << w;
+                FilterRecords(vecBest, exp, records, recordCount);
+            }
+
+            /* Write output */
+            for (int z = 0; z < 8; z++)
+            {
+                double d;
+                d = -vecBest[z][1] * 2048.0;
+                if (d > 0.0)
+                    coefs[z * 2] = (d > short.MaxValue) ? short.MaxValue : (short)Math.Round(d);
+                else
+                    coefs[z * 2] = (d < short.MinValue) ? short.MinValue : (short)Math.Round(d);
+
+                d = -vecBest[z][2] * 2048.0;
+                if (d > 0.0)
+                    coefs[z * 2 + 1] = (d > short.MaxValue) ? short.MaxValue : (short)Math.Round(d);
+                else
+                    coefs[z * 2 + 1] = (d < short.MinValue) ? short.MinValue : (short)Math.Round(d);
+            }
+            return coefs;
+        }
+
+        private static void InnerProductMerge(double[] vecOut, short[] pcmBuf)
+        {
+            for (int i = 0; i <= 2; i++)
+            {
+                vecOut[i] = 0.0f;
+                for (int x = 0; x < 14; x++)
+                    vecOut[i] -= pcmBuf[14 + x - i] * pcmBuf[14 + x];
+            }
+        }
+
+        private static void OuterProductMerge(double[][] mtxOut, short[] pcmBuf)
+        {
+            for (int x = 1; x <= 2; x++)
+            for (int y = 1; y <= 2; y++)
+            {
+                mtxOut[x][y] = 0.0;
+                for (int z = 0; z < 14; z++)
+                    mtxOut[x][y] += pcmBuf[14 + z - x] * pcmBuf[14 + z - y];
+            }
+        }
+
+        private static bool AnalyzeRanges(double[][] mtx, int[] vecIdxsOut, double[] recips)
+        {
+            double val, tmp, min, max;
+
+            /* Get greatest distance from zero */
+            for (int x = 1; x <= 2; x++)
+            {
+                val = Math.Max(Math.Abs(mtx[x][1]), Math.Abs(mtx[x][2]));
+                if (val < double.Epsilon)
+                    return true;
+
+                recips[x] = 1.0 / val;
+            }
+
+            int maxIndex = 0;
+            for (int i = 1; i <= 2; i++)
+            {
+                for (int x = 1; x < i; x++)
+                {
+                    tmp = mtx[x][i];
+                    for (int y = 1; y < x; y++)
+                        tmp -= mtx[x][y] * mtx[y][i];
+                    mtx[x][i] = tmp;
+                }
+
+                val = 0.0;
+                for (int x = i; x <= 2; x++)
+                {
+                    tmp = mtx[x][i];
+                    for (int y = 1; y < i; y++)
+                        tmp -= mtx[x][y] * mtx[y][i];
+
+                    mtx[x][i] = tmp;
+                    tmp = Math.Abs(tmp) * recips[x];
+                    if (tmp >= val)
+                    {
+                        val = tmp;
+                        maxIndex = x;
+                    }
+                }
+
+                if (maxIndex != i)
+                {
+                    for (int y = 1; y <= 2; y++)
+                    {
+                        tmp = mtx[maxIndex][y];
+                        mtx[maxIndex][y] = mtx[i][y];
+                        mtx[i][y] = tmp;
+                    }
+                    recips[maxIndex] = recips[i];
+                }
+
+                vecIdxsOut[i] = maxIndex;
+
+                if (i != 2)
+                {
+                    tmp = 1.0 / mtx[i][i];
+                    for (int x = i + 1; x <= 2; x++)
+                        mtx[x][i] *= tmp;
+                }
+            }
+
+            /* Get range */
+            min = 1.0e10;
+            max = 0.0;
+            for (int i = 1; i <= 2; i++)
+            {
+                tmp = Math.Abs(mtx[i][i]);
+                if (tmp < min)
+                    min = tmp;
+                if (tmp > max)
+                    max = tmp;
+            }
+
+            return min / max < 1.0e-10;
+        }
+
+        private static void BidirectionalFilter(double[][] mtx, int[] vecIdxs, double[] vecOut)
+        {
+            double tmp;
+
+            for (int i = 1, x = 0; i <= 2; i++)
+            {
+                int index = vecIdxs[i];
+                tmp = vecOut[index];
+                vecOut[index] = vecOut[i];
+                if (x != 0)
+                    for (int y = x; y <= i - 1; y++)
+                        tmp -= vecOut[y] * mtx[i][y];
+                // ReSharper disable once CompareOfFloatsByEqualityOperator
+                else if (tmp != 0.0)
+                    x = i;
+                vecOut[i] = tmp;
+            }
+
+            for (int i = 2; i > 0; i--)
+            {
+                tmp = vecOut[i];
+                for (int y = i + 1; y <= 2; y++)
+                    tmp -= vecOut[y] * mtx[i][y];
+                vecOut[i] = tmp / mtx[i][i];
+            }
+
+            vecOut[0] = 1.0;
+        }
+
+        private static bool QuadraticMerge(double[] inOutVec)
+        {
+            double v2 = inOutVec[2];
+            double tmp = 1.0 - (v2 * v2);
+
+            // ReSharper disable once CompareOfFloatsByEqualityOperator
+            if (tmp == 0.0)
+                return true;
+
+            double v0 = (inOutVec[0] - (v2 * v2)) / tmp;
+            double v1 = (inOutVec[1] - (inOutVec[1] * v2)) / tmp;
+
+            inOutVec[0] = v0;
+            inOutVec[1] = v1;
+
+            return Math.Abs(v1) > 1.0;
+        }
+
+        private static void FinishRecord(double[] inR, double[,] outR, int row)
+        {
+            for (int z = 1; z <= 2; z++)
+            {
+                if (inR[z] >= 1.0)
+                    inR[z] = 0.9999999999;
+                else if (inR[z] <= -1.0)
+                    inR[z] = -0.9999999999;
+            }
+            outR[row, 0] = 1.0;
+            outR[row, 1] = (inR[2] * inR[1]) + inR[1];
+            outR[row, 2] = inR[2];
+        }
+
+        private static void FinishRecord(double[] inR, double[] outR)
+        {
+            for (int z = 1; z <= 2; z++)
+            {
+                if (inR[z] >= 1.0)
+                    inR[z] = 0.9999999999;
+                else if (inR[z] <= -1.0)
+                    inR[z] = -0.9999999999;
+            }
+            outR[0] = 1.0;
+            outR[1] = (inR[2] * inR[1]) + inR[1];
+            outR[2] = inR[2];
+        }
+
+        private static void MatrixFilter(double[,] src, int row, double[] dst, double[][] mtx)
+        {
+            mtx[2][0] = 1.0;
+            for (int i = 1; i <= 2; i++)
+                mtx[2][i] = -src[row, i];
+
+            for (int i = 2; i > 0; i--)
+            {
+                double val = 1.0 - (mtx[i][i] * mtx[i][i]);
+                for (int y = 1; y <= i; y++)
+                    mtx[i - 1][y] = ((mtx[i][i] * mtx[i][y]) + mtx[i][y]) / val;
+            }
+
+            dst[0] = 1.0;
+            for (int i = 1; i <= 2; i++)
+            {
+                dst[i] = 0.0;
+                for (int y = 1; y <= i; y++)
+                    dst[i] += mtx[i][y] * dst[i - y];
+            }
+        }
+
+        private static void MergeFinishRecord(double[] src, double[] dst)
+        {
+            double[] tmp = new double[3];
+            double val = src[0];
+
+            dst[0] = 1.0;
+            for (int i = 1; i <= 2; i++)
+            {
+                double v2 = 0.0;
+                for (int y = 1; y < i; y++)
+                    v2 += dst[y] * src[i - y];
+
+                if (val > 0.0)
+                    dst[i] = -(v2 + src[i]) / val;
+                else
+                    dst[i] = 0.0;
+
+                tmp[i] = dst[i];
+
+                for (int y = 1; y < i; y++)
+                    dst[y] += dst[i] * dst[i - y];
+
+                val *= 1.0 - (dst[i] * dst[i]);
+            }
+
+            FinishRecord(tmp, dst);
+        }
+
+        private static double ContrastVectors(double[] source1, double[,] source2, int row)
+        {
+            double val = (source2[row, 2] * source2[row, 1] + -source2[row, 1]) / (1.0 - source2[row, 2] * source2[row, 2]);
+            double val1 = (source1[0] * source1[0]) + (source1[1] * source1[1]) + (source1[2] * source1[2]);
+            double val2 = (source1[0] * source1[1]) + (source1[1] * source1[2]);
+            double val3 = source1[0] * source1[2];
+            return val1 + (2.0 * val * val2) + (2.0 * (-source2[row, 1] * val + -source2[row, 2]) * val3);
+        }
+
+        private static void FilterRecords(double[][] vecBest, int exp, double[,] records, int recordCount)
+        {
+            double[][] bufferList = new double[8][];
+            for (int i = 0; i < bufferList.Length; i++)
+            {
+                bufferList[i] = new double[3];
+            }
+
+            double[][] mtx = new double[3][];
+            for (int i = 0; i < mtx.Length; i++)
+            {
+                mtx[i] = new double[3];
+            }
+
+            int[] buffer1 = new int[8];
+            double[] buffer2 = new double[3];
+
+            for (int x = 0; x < 2; x++)
+            {
+                for (int y = 0; y < exp; y++)
+                {
+                    buffer1[y] = 0;
+                    for (int i = 0; i <= 2; i++)
+                        bufferList[y][i] = 0.0;
+                }
+                for (int z = 0; z < recordCount; z++)
+                {
+                    var index = 0;
+                    var value = 1.0e30;
+                    for (int i = 0; i < exp; i++)
+                    {
+                        double tempVal = ContrastVectors(vecBest[i], records, z);
+                        if (tempVal < value)
+                        {
+                            value = tempVal;
+                            index = i;
+                        }
+                    }
+                    buffer1[index]++;
+                    MatrixFilter(records, z, buffer2, mtx);
+                    for (int i = 0; i <= 2; i++)
+                        bufferList[index][i] += buffer2[i];
+                }
+
+                for (int i = 0; i < exp; i++)
+                    if (buffer1[i] > 0)
+                        for (int y = 0; y <= 2; y++)
+                            bufferList[i][y] /= buffer1[i];
+
+                for (int i = 0; i < exp; i++)
+                    MergeFinishRecord(bufferList[i], vecBest[i]);
+            }
+        }
+    }
+}

--- a/src/VGAudio/Codecs/GcAdpcmEncoder.cs
+++ b/src/VGAudio/Codecs/GcAdpcmEncoder.cs
@@ -11,393 +11,37 @@ namespace VGAudio.Codecs
     /// </summary>
     public static class GcAdpcmEncoder
     {
-        private static void InnerProductMerge(double[] vecOut, short[] pcmBuf)
+        public static byte[] EncodeAdpcm(short[] pcm, short[] coefs, int samples = -1, short hist1 = 0,
+            short hist2 = 0)
         {
-            for (int i = 0; i <= 2; i++)
+            int sampleCount = samples == -1 ? pcm.Length : samples;
+            var adpcm = new byte[SampleCountToByteCount(sampleCount)];
+
+            /* Execute encoding-predictor for each frame */
+            var pcmBuffer = new short[2 + SamplesPerFrame];
+            var adpcmBuffer = new byte[BytesPerFrame];
+
+            pcmBuffer[0] = hist2;
+            pcmBuffer[1] = hist1;
+
+            int frameCount = sampleCount.DivideByRoundUp(SamplesPerFrame);
+            var buffers = new AdpcmEncodeBuffers();
+
+            for (int frame = 0; frame < frameCount; frame++)
             {
-                vecOut[i] = 0.0f;
-                for (int x = 0; x < 14; x++)
-                    vecOut[i] -= pcmBuf[14 + x - i] * pcmBuf[14 + x];
-            }
-        }
+                int samplesToCopy = Math.Min(sampleCount - frame * SamplesPerFrame, SamplesPerFrame);
+                Array.Copy(pcm, frame * SamplesPerFrame, pcmBuffer, 2, samplesToCopy);
+                Array.Clear(pcmBuffer, 2 + samplesToCopy, SamplesPerFrame - samplesToCopy);
 
-        private static void OuterProductMerge(double[][] mtxOut, short[] pcmBuf)
-        {
-            for (int x = 1; x <= 2; x++)
-                for (int y = 1; y <= 2; y++)
-                {
-                    mtxOut[x][y] = 0.0;
-                    for (int z = 0; z < 14; z++)
-                        mtxOut[x][y] += pcmBuf[14 + z - x] * pcmBuf[14 + z - y];
-                }
-        }
+                DspEncodeFrame(pcmBuffer, SamplesPerFrame, adpcmBuffer, coefs, buffers);
 
-        private static bool AnalyzeRanges(double[][] mtx, int[] vecIdxsOut, double[] recips)
-        {
-            double val, tmp, min, max;
+                Array.Copy(adpcmBuffer, 0, adpcm, frame * BytesPerFrame, SampleCountToByteCount(samplesToCopy));
 
-            /* Get greatest distance from zero */
-            for (int x = 1; x <= 2; x++)
-            {
-                val = Math.Max(Math.Abs(mtx[x][1]), Math.Abs(mtx[x][2]));
-                if (val < double.Epsilon)
-                    return true;
-
-                recips[x] = 1.0 / val;
+                pcmBuffer[0] = pcmBuffer[14];
+                pcmBuffer[1] = pcmBuffer[15];
             }
 
-            int maxIndex = 0;
-            for (int i = 1; i <= 2; i++)
-            {
-                for (int x = 1; x < i; x++)
-                {
-                    tmp = mtx[x][i];
-                    for (int y = 1; y < x; y++)
-                        tmp -= mtx[x][y] * mtx[y][i];
-                    mtx[x][i] = tmp;
-                }
-
-                val = 0.0;
-                for (int x = i; x <= 2; x++)
-                {
-                    tmp = mtx[x][i];
-                    for (int y = 1; y < i; y++)
-                        tmp -= mtx[x][y] * mtx[y][i];
-
-                    mtx[x][i] = tmp;
-                    tmp = Math.Abs(tmp) * recips[x];
-                    if (tmp >= val)
-                    {
-                        val = tmp;
-                        maxIndex = x;
-                    }
-                }
-
-                if (maxIndex != i)
-                {
-                    for (int y = 1; y <= 2; y++)
-                    {
-                        tmp = mtx[maxIndex][y];
-                        mtx[maxIndex][y] = mtx[i][y];
-                        mtx[i][y] = tmp;
-                    }
-                    recips[maxIndex] = recips[i];
-                }
-
-                vecIdxsOut[i] = maxIndex;
-
-                if (i != 2)
-                {
-                    tmp = 1.0 / mtx[i][i];
-                    for (int x = i + 1; x <= 2; x++)
-                        mtx[x][i] *= tmp;
-                }
-            }
-
-            /* Get range */
-            min = 1.0e10;
-            max = 0.0;
-            for (int i = 1; i <= 2; i++)
-            {
-                tmp = Math.Abs(mtx[i][i]);
-                if (tmp < min)
-                    min = tmp;
-                if (tmp > max)
-                    max = tmp;
-            }
-
-            return min / max < 1.0e-10;
-        }
-
-        private static void BidirectionalFilter(double[][] mtx, int[] vecIdxs, double[] vecOut)
-        {
-            double tmp;
-
-            for (int i = 1, x = 0; i <= 2; i++)
-            {
-                int index = vecIdxs[i];
-                tmp = vecOut[index];
-                vecOut[index] = vecOut[i];
-                if (x != 0)
-                    for (int y = x; y <= i - 1; y++)
-                        tmp -= vecOut[y] * mtx[i][y];
-                // ReSharper disable once CompareOfFloatsByEqualityOperator
-                else if (tmp != 0.0)
-                    x = i;
-                vecOut[i] = tmp;
-            }
-
-            for (int i = 2; i > 0; i--)
-            {
-                tmp = vecOut[i];
-                for (int y = i + 1; y <= 2; y++)
-                    tmp -= vecOut[y] * mtx[i][y];
-                vecOut[i] = tmp / mtx[i][i];
-            }
-
-            vecOut[0] = 1.0;
-        }
-
-        private static bool QuadraticMerge(double[] inOutVec)
-        {
-            double v2 = inOutVec[2];
-            double tmp = 1.0 - (v2 * v2);
-
-            // ReSharper disable once CompareOfFloatsByEqualityOperator
-            if (tmp == 0.0)
-                return true;
-
-            double v0 = (inOutVec[0] - (v2 * v2)) / tmp;
-            double v1 = (inOutVec[1] - (inOutVec[1] * v2)) / tmp;
-
-            inOutVec[0] = v0;
-            inOutVec[1] = v1;
-
-            return Math.Abs(v1) > 1.0;
-        }
-
-        private static void FinishRecord(double[] inR, double[,] outR, int row)
-        {
-            for (int z = 1; z <= 2; z++)
-            {
-                if (inR[z] >= 1.0)
-                    inR[z] = 0.9999999999;
-                else if (inR[z] <= -1.0)
-                    inR[z] = -0.9999999999;
-            }
-            outR[row, 0] = 1.0;
-            outR[row, 1] = (inR[2] * inR[1]) + inR[1];
-            outR[row, 2] = inR[2];
-        }
-
-        private static void FinishRecord(double[] inR, double[] outR)
-        {
-            for (int z = 1; z <= 2; z++)
-            {
-                if (inR[z] >= 1.0)
-                    inR[z] = 0.9999999999;
-                else if (inR[z] <= -1.0)
-                    inR[z] = -0.9999999999;
-            }
-            outR[0] = 1.0;
-            outR[1] = (inR[2] * inR[1]) + inR[1];
-            outR[2] = inR[2];
-        }
-
-        private static void MatrixFilter(double[,] src, int row, double[] dst, double[][] mtx)
-        {
-            mtx[2][0] = 1.0;
-            for (int i = 1; i <= 2; i++)
-                mtx[2][i] = -src[row, i];
-
-            for (int i = 2; i > 0; i--)
-            {
-                double val = 1.0 - (mtx[i][i] * mtx[i][i]);
-                for (int y = 1; y <= i; y++)
-                    mtx[i - 1][y] = ((mtx[i][i] * mtx[i][y]) + mtx[i][y]) / val;
-            }
-
-            dst[0] = 1.0;
-            for (int i = 1; i <= 2; i++)
-            {
-                dst[i] = 0.0;
-                for (int y = 1; y <= i; y++)
-                    dst[i] += mtx[i][y] * dst[i - y];
-            }
-        }
-
-        private static void MergeFinishRecord(double[] src, double[] dst)
-        {
-            double[] tmp = new double[3];
-            double val = src[0];
-
-            dst[0] = 1.0;
-            for (int i = 1; i <= 2; i++)
-            {
-                double v2 = 0.0;
-                for (int y = 1; y < i; y++)
-                    v2 += dst[y] * src[i - y];
-
-                if (val > 0.0)
-                    dst[i] = -(v2 + src[i]) / val;
-                else
-                    dst[i] = 0.0;
-
-                tmp[i] = dst[i];
-
-                for (int y = 1; y < i; y++)
-                    dst[y] += dst[i] * dst[i - y];
-
-                val *= 1.0 - (dst[i] * dst[i]);
-            }
-
-            FinishRecord(tmp, dst);
-        }
-
-        private static double ContrastVectors(double[] source1, double[,] source2, int row)
-        {
-            double val = (source2[row, 2] * source2[row, 1] + -source2[row, 1]) / (1.0 - source2[row, 2] * source2[row, 2]);
-            double val1 = (source1[0] * source1[0]) + (source1[1] * source1[1]) + (source1[2] * source1[2]);
-            double val2 = (source1[0] * source1[1]) + (source1[1] * source1[2]);
-            double val3 = source1[0] * source1[2];
-            return val1 + (2.0 * val * val2) + (2.0 * (-source2[row, 1] * val + -source2[row, 2]) * val3);
-        }
-
-        private static void FilterRecords(double[][] vecBest, int exp, double[,] records, int recordCount)
-        {
-            double[][] bufferList = new double[8][];
-            for (int i = 0; i < bufferList.Length; i++)
-            {
-                bufferList[i] = new double[3];
-            }
-
-            double[][] mtx = new double[3][];
-            for (int i = 0; i < mtx.Length; i++)
-            {
-                mtx[i] = new double[3];
-            }
-
-            int[] buffer1 = new int[8];
-            double[] buffer2 = new double[3];
-
-            for (int x = 0; x < 2; x++)
-            {
-                for (int y = 0; y < exp; y++)
-                {
-                    buffer1[y] = 0;
-                    for (int i = 0; i <= 2; i++)
-                        bufferList[y][i] = 0.0;
-                }
-                for (int z = 0; z < recordCount; z++)
-                {
-                    var index = 0;
-                    var value = 1.0e30;
-                    for (int i = 0; i < exp; i++)
-                    {
-                        double tempVal = ContrastVectors(vecBest[i], records, z);
-                        if (tempVal < value)
-                        {
-                            value = tempVal;
-                            index = i;
-                        }
-                    }
-                    buffer1[index]++;
-                    MatrixFilter(records, z, buffer2, mtx);
-                    for (int i = 0; i <= 2; i++)
-                        bufferList[index][i] += buffer2[i];
-                }
-
-                for (int i = 0; i < exp; i++)
-                    if (buffer1[i] > 0)
-                        for (int y = 0; y <= 2; y++)
-                            bufferList[i][y] /= buffer1[i];
-
-                for (int i = 0; i < exp; i++)
-                    MergeFinishRecord(bufferList[i], vecBest[i]);
-            }
-        }
-
-        public static short[] DspCorrelateCoefs(short[] source)
-        {
-            int frameCount = source.Length.DivideByRoundUp(SamplesPerFrame);
-
-            short[] pcmHistBuffer = new short[28];
-
-            short[] coefs = new short[16];
-
-            double[] vec1 = new double[3];
-            double[] vec2 = new double[3];
-            double[] buffer = new double[3];
-
-            double[][] mtx = new double[3][];
-            for (int i = 0; i < mtx.Length; i++)
-            {
-                mtx[i] = new double[3];
-            }
-
-            int[] vecIdxs = new int[3];
-
-            double[,] records = new double[frameCount * 2, 3];
-
-            int recordCount = 0;
-
-            double[][] vecBest = new double[8][];
-            for (int i = 0; i < vecBest.Length; i++)
-            {
-                vecBest[i] = new double[3];
-            }
-
-            /* Iterate though one frame at a time */
-            for (int sample = 0, remaining = source.Length; sample < source.Length; sample += 14, remaining -= 14)
-            {
-                Array.Clear(pcmHistBuffer, 14, 14);
-                Array.Copy(source, sample, pcmHistBuffer, 14, Math.Min(14, remaining));
-
-                InnerProductMerge(vec1, pcmHistBuffer);
-                if (Math.Abs(vec1[0]) > 10.0)
-                {
-                    OuterProductMerge(mtx, pcmHistBuffer);
-                    if (!AnalyzeRanges(mtx, vecIdxs, buffer))
-                    {
-                        BidirectionalFilter(mtx, vecIdxs, vec1);
-                        if (!QuadraticMerge(vec1))
-                        {
-                            FinishRecord(vec1, records, recordCount);
-                            recordCount++;
-                        }
-                    }
-                }
-
-                Array.Copy(pcmHistBuffer, 14, pcmHistBuffer, 0, 14);
-            }
-
-            vec1[0] = 1.0;
-            vec1[1] = 0.0;
-            vec1[2] = 0.0;
-
-            for (int z = 0; z < recordCount; z++)
-            {
-                MatrixFilter(records, z, vecBest[0], mtx);
-                for (int y = 1; y <= 2; y++)
-                    vec1[y] += vecBest[0][y];
-            }
-            for (int y = 1; y <= 2; y++)
-                vec1[y] /= recordCount;
-
-            MergeFinishRecord(vec1, vecBest[0]);
-
-
-            int exp = 1;
-            for (int w = 0; w < 3;)
-            {
-                vec2[0] = 0.0;
-                vec2[1] = -1.0;
-                vec2[2] = 0.0;
-                for (int i = 0; i < exp; i++)
-                    for (int y = 0; y <= 2; y++)
-                        vecBest[exp + i][y] = (0.01 * vec2[y]) + vecBest[i][y];
-                ++w;
-                exp = 1 << w;
-                FilterRecords(vecBest, exp, records, recordCount);
-            }
-
-            /* Write output */
-            for (int z = 0; z < 8; z++)
-            {
-                double d;
-                d = -vecBest[z][1] * 2048.0;
-                if (d > 0.0)
-                    coefs[z * 2] = (d > short.MaxValue) ? short.MaxValue : (short)Math.Round(d);
-                else
-                    coefs[z * 2] = (d < short.MinValue) ? short.MinValue : (short)Math.Round(d);
-
-                d = -vecBest[z][2] * 2048.0;
-                if (d > 0.0)
-                    coefs[z * 2 + 1] = (d > short.MaxValue) ? short.MaxValue : (short)Math.Round(d);
-                else
-                    coefs[z * 2 + 1] = (d < short.MinValue) ? short.MinValue : (short)Math.Round(d);
-            }
-            return coefs;
+            return adpcm;
         }
 
         public static void DspEncodeFrame(short[] pcmInOut, int sampleCount, byte[] adpcmOut, short[] coefsIn,
@@ -434,7 +78,7 @@ namespace VGAudio.Codecs
             for (int s = 0; s < sampleCount; s++)
                 pcmInOut[s + 2] = (short)b.InSamples[bestIndex][s + 2];
 
-            /* Write ps */
+            /* Write predictor and scale */
             adpcmOut[0] = (byte)((bestIndex << 4) | (b.Scale[bestIndex] & 0xF));
 
             /* Zero remaining samples */
@@ -523,39 +167,6 @@ namespace VGAudio.Codecs
                         scalePower = 11;
 
             } while (scalePower < 12 && maxOverflow > 1);
-        }
-
-        public static byte[] EncodeAdpcm(short[] pcm, short[] coefs, int samples = -1, short hist1 = 0,
-            short hist2 = 0)
-        {
-            int sampleCount = samples == -1 ? pcm.Length : samples;
-            var adpcm = new byte[SampleCountToByteCount(sampleCount)];
-
-            /* Execute encoding-predictor for each frame */
-            var pcmBuffer = new short[2 + SamplesPerFrame];
-            var adpcmBuffer = new byte[BytesPerFrame];
-
-            pcmBuffer[0] = hist2;
-            pcmBuffer[1] = hist1;
-
-            int frameCount = sampleCount.DivideByRoundUp(SamplesPerFrame);
-            var buffers = new AdpcmEncodeBuffers();
-
-            for (int frame = 0; frame < frameCount; frame++)
-            {
-                int samplesToCopy = Math.Min(sampleCount - frame * SamplesPerFrame, SamplesPerFrame);
-                Array.Copy(pcm, frame * SamplesPerFrame, pcmBuffer, 2, samplesToCopy);
-                Array.Clear(pcmBuffer, 2 + samplesToCopy, SamplesPerFrame - samplesToCopy);
-
-                DspEncodeFrame(pcmBuffer, SamplesPerFrame, adpcmBuffer, coefs, buffers);
-
-                Array.Copy(adpcmBuffer, 0, adpcm, frame * BytesPerFrame, SampleCountToByteCount(samplesToCopy));
-
-                pcmBuffer[0] = pcmBuffer[14];
-                pcmBuffer[1] = pcmBuffer[15];
-            }
-
-            return adpcm;
         }
 
         public class AdpcmEncodeBuffers

--- a/src/VGAudio/Containers/Hps/HpsStructure.cs
+++ b/src/VGAudio/Containers/Hps/HpsStructure.cs
@@ -9,7 +9,7 @@ namespace VGAudio.Containers.Hps
         public bool Looping { get; set; }
         public int LoopStart { get; set; }
         public int SampleCount { get; set; }
-        public List<HpsChannelInfo> ChannelInfo { get; } = new List<HpsChannelInfo>();
+        public List<HpsChannelInfo> Channels { get; } = new List<HpsChannelInfo>();
         public List<HpsBlock> Blocks { get; } = new List<HpsBlock>();
     }
 }

--- a/src/VGAudio/Containers/HpsReader.cs
+++ b/src/VGAudio/Containers/HpsReader.cs
@@ -49,16 +49,16 @@ namespace VGAudio.Containers
                     currentPosition += source.Length;
                 }
 
-                var channelBuilder = new GcAdpcmChannelBuilder(audio, structure.ChannelInfo[c].Coefs, structure.ChannelInfo[c].SampleCount)
+                var channelBuilder = new GcAdpcmChannelBuilder(audio, structure.Channels[c].Coefs, structure.Channels[c].SampleCount)
                 {
-                    Gain = structure.ChannelInfo[c].Gain,
-                    Hist1 = structure.ChannelInfo[c].Hist1,
-                    Hist2 = structure.ChannelInfo[c].Hist2
+                    Gain = structure.Channels[c].Gain,
+                    Hist1 = structure.Channels[c].Hist1,
+                    Hist2 = structure.Channels[c].Hist2
                 };
 
                 channelBuilder.WithLoop(structure.Looping, structure.LoopStart, structure.SampleCount)
-                    .WithLoopContext(structure.LoopStart, structure.ChannelInfo[c].LoopPredScale,
-                        structure.ChannelInfo[c].LoopHist1, structure.ChannelInfo[c].LoopHist2);
+                    .WithLoopContext(structure.LoopStart, structure.Channels[c].LoopPredScale,
+                        structure.Channels[c].LoopHist1, structure.Channels[c].LoopHist2);
 
                 channels[c] = channelBuilder.Build();
             }
@@ -86,7 +86,7 @@ namespace VGAudio.Containers
                 channel.Hist1 = reader.ReadInt16();
                 channel.Hist2 = reader.ReadInt16();
 
-                structure.ChannelInfo.Add(channel);
+                structure.Channels.Add(channel);
             }
         }
 
@@ -135,8 +135,8 @@ namespace VGAudio.Containers
 
         private static void VerifyData(HpsStructure structure)
         {
-            structure.SampleCount = structure.ChannelInfo.First().SampleCount;
-            if (structure.ChannelInfo.Any(x => x.SampleCount != structure.SampleCount))
+            structure.SampleCount = structure.Channels.First().SampleCount;
+            if (structure.Channels.Any(x => x.SampleCount != structure.SampleCount))
             {
                 throw new InvalidDataException("Channels have differing sample counts");
             }
@@ -154,11 +154,11 @@ namespace VGAudio.Containers
                     structure.Looping = true;
                     structure.LoopStart = GcAdpcmHelpers.NibbleCountToSampleCount(currentNibble);
 
-                    for (int i = 0; i < structure.ChannelInfo.Count; i++)
+                    for (int i = 0; i < structure.Channels.Count; i++)
                     {
-                        structure.ChannelInfo[i].LoopPredScale = block.Channels[i].PredScale;
-                        structure.ChannelInfo[i].LoopHist1 = block.Channels[i].Hist1;
-                        structure.ChannelInfo[i].LoopHist2 = block.Channels[i].Hist2;
+                        structure.Channels[i].LoopPredScale = block.Channels[i].PredScale;
+                        structure.Channels[i].LoopHist1 = block.Channels[i].Hist1;
+                        structure.Channels[i].LoopHist2 = block.Channels[i].Hist2;
                     }
                 }
                 currentNibble += block.FinalNibble + 1;

--- a/src/VGAudio/Formats/GcAdpcmFormat.cs
+++ b/src/VGAudio/Formats/GcAdpcmFormat.cs
@@ -123,7 +123,7 @@ namespace VGAudio.Formats
 
         private static GcAdpcmChannel EncodeChannel(int sampleCount, short[] pcm)
         {
-            short[] coefs = GcAdpcmEncoder.DspCorrelateCoefs(pcm);
+            short[] coefs = GcAdpcmCoefficient.CalculateCoefficients(pcm);
             byte[] adpcm = GcAdpcmEncoder.EncodeAdpcm(pcm, coefs);
 
             return new GcAdpcmChannel(adpcm, coefs, sampleCount);

--- a/src/VGAudio/Utilities/Helpers.cs
+++ b/src/VGAudio/Utilities/Helpers.cs
@@ -16,6 +16,15 @@ namespace VGAudio.Utilities
             return (short)value;
         }
 
+        public static sbyte Clamp4(int value)
+        {
+            if (value > 7)
+                return 7;
+            if (value < -8)
+                return -8;
+            return (sbyte)value;
+        }
+
         private static sbyte[] _signedNibbles = { 0, 1, 2, 3, 4, 5, 6, 7, -8, -7, -6, -5, -4, -3, -2, -1 };
 
         public static byte GetHighNibble(byte value) => (byte)((value >> 4) & 0xF);

--- a/src/VGAudio/Utilities/Helpers.cs
+++ b/src/VGAudio/Utilities/Helpers.cs
@@ -16,8 +16,13 @@ namespace VGAudio.Utilities
             return (short)value;
         }
 
+        private static sbyte[] _signedNibbles = { 0, 1, 2, 3, 4, 5, 6, 7, -8, -7, -6, -5, -4, -3, -2, -1 };
+
         public static byte GetHighNibble(byte value) => (byte)((value >> 4) & 0xF);
         public static byte GetLowNibble(byte value) => (byte)(value & 0xF);
+
+        public static sbyte GetHighNibbleSigned(byte value) => _signedNibbles[(value >> 4) & 0xF];
+        public static sbyte GetLowNibbleSigned(byte value) => _signedNibbles[value & 0xF];
 
         public static int GetNextMultiple(int value, int multiple)
         {

--- a/src/VGAudio/Utilities/Helpers.cs
+++ b/src/VGAudio/Utilities/Helpers.cs
@@ -25,13 +25,15 @@ namespace VGAudio.Utilities
             return (sbyte)value;
         }
 
-        private static sbyte[] _signedNibbles = { 0, 1, 2, 3, 4, 5, 6, 7, -8, -7, -6, -5, -4, -3, -2, -1 };
+        private static readonly sbyte[] SignedNibbles = { 0, 1, 2, 3, 4, 5, 6, 7, -8, -7, -6, -5, -4, -3, -2, -1 };
 
         public static byte GetHighNibble(byte value) => (byte)((value >> 4) & 0xF);
         public static byte GetLowNibble(byte value) => (byte)(value & 0xF);
 
-        public static sbyte GetHighNibbleSigned(byte value) => _signedNibbles[(value >> 4) & 0xF];
-        public static sbyte GetLowNibbleSigned(byte value) => _signedNibbles[value & 0xF];
+        public static sbyte GetHighNibbleSigned(byte value) => SignedNibbles[(value >> 4) & 0xF];
+        public static sbyte GetLowNibbleSigned(byte value) => SignedNibbles[value & 0xF];
+
+        public static byte CombineNibbles(int high, int low) => (byte)((high << 4) | (low & 0xF));
 
         public static int GetNextMultiple(int value, int multiple)
         {
@@ -43,7 +45,6 @@ namespace VGAudio.Utilities
 
             return value + multiple - value % multiple;
         }
-
 
         public static bool LoopPointsAreAligned(int loopStart, int alignmentMultiple)
             => !(alignmentMultiple != 0 && loopStart % alignmentMultiple != 0);


### PR DESCRIPTION
This makes the GC ADPCM encoder and decoder code easier to read, creates a few common helper methods to deal with nibbles, and separates the coefficient calculation into its own class.