### PR TITLE
Add encrypted ADX support

### DIFF
--- a/src/VGAudio.Cli/CliArguments.cs
+++ b/src/VGAudio.Cli/CliArguments.cs
@@ -193,6 +193,31 @@ namespace VGAudio.Cli
                             options.AdxType = adxType;
                             i++;
                             continue;
+                        case "-KEYSTRING":
+                            if (i + 1 >= args.Length)
+                            {
+                                PrintWithUsage("No argument after --keystring.");
+                                return null;
+                            }
+
+                            options.KeyString = args[i + 1];
+                            i++;
+                            continue;
+                        case "-KEYCODE":
+                            if (i + 1 >= args.Length)
+                            {
+                                PrintWithUsage("No argument after --keycode.");
+                                return null;
+                            }
+                            if (!ulong.TryParse(args[i + 1], out ulong keycode))
+                            {
+                                PrintWithUsage("Error parsing key code.");
+                                return null;
+                            }
+
+                            options.KeyCode = keycode;
+                            i++;
+                            continue;
                     }
                 }
 

--- a/src/VGAudio.Cli/CreateConfiguration.cs
+++ b/src/VGAudio.Cli/CreateConfiguration.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using VGAudio.Codecs.CriAdx;
 using VGAudio.Containers;
 using VGAudio.Containers.Adx;
 using VGAudio.Containers.Bxstm;
@@ -144,6 +145,16 @@ namespace VGAudio.Cli
             if (options.FrameSize != 0) config.FrameSize = options.FrameSize;
             if (options.Filter >= 0 && options.Filter <= 3) config.Filter = options.Filter;
             if (options.AdxType != default(CriAdxType)) config.Type = options.AdxType;
+            if (options.KeyString != null)
+            {
+                config.EncryptionKey = new CriAdxKey(options.KeyString);
+                config.EncryptionType = 8;
+            }
+            if (options.KeyCode != 0)
+            {
+                config.EncryptionKey = new CriAdxKey(options.KeyCode);
+                config.EncryptionType = 9;
+            }
             return config;
         }
     }

--- a/src/VGAudio.Cli/Options.cs
+++ b/src/VGAudio.Cli/Options.cs
@@ -22,6 +22,8 @@ namespace VGAudio.Cli
         public int FrameSize { get; set; } // ADX
         public int Filter { get; set; } = 2; // ADX
         public CriAdxType AdxType { get; set; } // ADX
+        public string KeyString { get; set; } //ADX
+        public ulong KeyCode { get; set; } //ADX
     }
 
     internal class AudioFile

--- a/src/VGAudio.Tools/CrackAdx/GuessAdx.cs
+++ b/src/VGAudio.Tools/CrackAdx/GuessAdx.cs
@@ -236,7 +236,7 @@ namespace VGAudio.Tools.CrackAdx
                 adx = (CriAdxFormat)new AdxReader().ReadFormat(stream);
             }
 
-            CriAdxEncryption.Decrypt(adx.Channels.Select(x => x.Audio).ToArray(), key, adx.FrameSize);
+            CriAdxEncryption.EncryptDecrypt(adx.Channels.Select(x => x.Audio).ToArray(), key, EncryptionType, adx.FrameSize);
             Pcm16Format pcm = adx.ToPcm16();
             CriAdxFormat adx2 = new CriAdxFormat().EncodeFromPcm16(pcm);
 

--- a/src/VGAudio/Codecs/CriAdx/CriAdxEncryption.cs
+++ b/src/VGAudio/Codecs/CriAdx/CriAdxEncryption.cs
@@ -1,18 +1,19 @@
-﻿using VGAudio.Utilities;
+﻿using System.Collections.Generic;
+using VGAudio.Utilities;
 
 namespace VGAudio.Codecs.CriAdx
 {
     public static partial class CriAdxEncryption
     {
-        public static void Decrypt(byte[][] adpcm, CriAdxKey key, int frameSize)
+        public static void EncryptDecrypt(byte[][] adpcm, CriAdxKey key, int encryptionType, int frameSize)
         {
             for (int i = 0; i < adpcm.Length; i++)
             {
-                DecryptChannel(adpcm[i], key, frameSize, i, adpcm.Length);
+                EncryptDecryptChannel(adpcm[i], key, encryptionType, frameSize, i, adpcm.Length);
             }
         }
 
-        public static void DecryptChannel(byte[] adpcm, CriAdxKey key, int frameSize, int channelNum, int channelCount)
+        public static void EncryptDecryptChannel(byte[] adpcm, CriAdxKey key, int encryptionType, int frameSize, int channelNum, int channelCount)
         {
             int xor = key.Seed;
             int frameCount = adpcm.Length.DivideByRoundUp(frameSize);
@@ -25,10 +26,10 @@ namespace VGAudio.Codecs.CriAdx
             for (int i = 0; i < frameCount; i++)
             {
                 int pos = i * frameSize;
-                if (adpcm[pos] != 0 || adpcm[pos + 1] != 0)
+                if (FrameNotEmpty(adpcm, pos, frameSize))
                 {
                     adpcm[pos] ^= (byte)(xor >> 8);
-                    adpcm[pos] &= 0x1f;
+                    if (encryptionType == 9) adpcm[pos] &= 0x1f;
                     adpcm[pos + 1] ^= (byte)xor;
                 }
 
@@ -37,6 +38,72 @@ namespace VGAudio.Codecs.CriAdx
                     xor = (xor * key.Mult + key.Inc) & 0x7fff;
                 }
             }
+        }
+
+        public static CriAdxKey FindKey(byte[][] adpcm, int encryptionType, int frameSize)
+        {
+            ushort[] scales = GetScales(adpcm, frameSize);
+            List<CriAdxKey> keys = encryptionType == 8 ? Keys8 : Keys9;
+
+            foreach (CriAdxKey key in keys)
+            {
+                if (TestKey(key, encryptionType, scales))
+                {
+                    return key;
+                }
+            }
+
+            return null;
+        }
+
+        private static ushort[] GetScales(byte[][] adpcm, int frameSize)
+        {
+            if (adpcm.Length < 1) return null;
+
+            int channelCount = adpcm.Length;
+            int frameCount = adpcm[0].Length.DivideByRoundUp(frameSize);
+            var scales = new ushort[frameCount * channelCount];
+
+            for (int frame = 0; frame < frameCount; frame++)
+            {
+                for (int channel = 0; channel < channelCount; channel++)
+                {
+                    int pos = frame * frameSize;
+                    scales[frame * channelCount + channel] = (ushort)(adpcm[channel][pos] << 8 | adpcm[channel][pos + 1]);
+                }
+            }
+
+            return scales;
+        }
+
+        private static bool TestKey(CriAdxKey key, int encryptionType, ushort[] scales)
+        {
+            int validationMask = encryptionType == 8 ? 0xE000 : 0x1000;
+            int xorMask = 0x7fff;
+
+            int xor = key.Seed;
+            foreach (ushort scale in scales)
+            {
+                if (((scale ^ xor) & validationMask) != 0 && scale != 0)
+                {
+                    return false;
+                }
+                xor = (xor * key.Mult + key.Inc) & xorMask;
+            }
+            return true;
+        }
+
+        private static bool FrameNotEmpty(byte[] bytes, int start, int length)
+        {
+            int end = start + length;
+            for (int i = start; i < end; i++)
+            {
+                if (bytes[i] != 0)
+                {
+                    return true;
+                }
+            }
+            return false;
         }
     }
 }

--- a/src/VGAudio/Codecs/CriAdx/CriAdxEncryption.cs
+++ b/src/VGAudio/Codecs/CriAdx/CriAdxEncryption.cs
@@ -2,7 +2,7 @@
 
 namespace VGAudio.Codecs.CriAdx
 {
-    public static class CriAdxEncryption
+    public static partial class CriAdxEncryption
     {
         public static void Decrypt(byte[][] adpcm, CriAdxKey key, int frameSize)
         {

--- a/src/VGAudio/Codecs/CriAdx/CriAdxEncryptionKeys.cs
+++ b/src/VGAudio/Codecs/CriAdx/CriAdxEncryptionKeys.cs
@@ -1,0 +1,225 @@
+using System.Collections.Generic;
+
+namespace VGAudio.Codecs.CriAdx
+{
+    public static partial class CriAdxEncryption
+    {
+        public static readonly List<CriAdxKey> Keys8 = new List<CriAdxKey>
+        {
+            // Clover Studio (GOD HAND, Okami) 
+            // Found in the game's executable
+            new CriAdxKey("karaage"),
+
+            // Grasshopper Manufacture 0 (Blood+)
+            // This is estimated
+            new CriAdxKey(0x5f5d, 0x58bd, 0x55ed),
+
+            // Grasshopper Manufacture 1 (Killer7)
+            // This is estimated
+            new CriAdxKey(0x50fb, 0x5803, 0x5701),
+
+            // Grasshopper Manufacture 2 (Samurai Champloo)
+            // Confirmed unique with guessadx
+            new CriAdxKey(0x4f3f, 0x472f, 0x562f),
+
+            // Moss Ltd (Raiden III)
+            // This is estimated
+            new CriAdxKey(0x66f5, 0x58bd, 0x4459),
+
+            // Sonic Team 0 (Phantasy Star Universe)
+            // Found in the game's executable
+            new CriAdxKey("3x5k62bg9ptbwy"),
+
+            // G.rev 0 (Senko no Ronde)
+            // This is estimated
+            new CriAdxKey(0x46d3, 0x5ced, 0x474d),
+
+            // Sonic Team 1 (NiGHTS: Journey of Dreams)
+            // This seems to be dead on, but still estimated
+            new CriAdxKey(0x440b, 0x6539, 0x5723),
+
+            // From guessadx (unique?), unknown source
+            new CriAdxKey(0x586d, 0x5d65, 0x63eb),
+
+            // Navel (Shuffle! On the Stage)
+            // 2nd key from guessadx
+            new CriAdxKey(0x4969, 0x5deb, 0x467f),
+
+            // Success (Aoishiro)
+            // 1st key from guessadx
+            new CriAdxKey(0x4d65, 0x5eb7, 0x5dfd),
+
+            // Sonic Team 2 (Sonic and the Black Knight)
+            // Found in the game's executable
+            new CriAdxKey("morio"),
+
+            // Enterbrain (Amagami)
+            // Found in the game's executable
+            new CriAdxKey("mituba"),
+
+            // Yamasa (Yamasa Digi Portable: Matsuri no Tatsujin)
+            // Confirmed unique with guessadx
+            new CriAdxKey(0x4c01, 0x549d, 0x676f),
+
+            // Kadokawa Shoten (Fragments Blue)
+            // Confirmed unique with guessadx
+            new CriAdxKey(0x5803, 0x4555, 0x47bf),
+
+            // Namco (Soulcalibur IV)
+            // Confirmed unique with guessadx
+            new CriAdxKey(0x59ed, 0x4679, 0x46c9),
+
+            // G.rev 1 (Senko no Ronde DUO)
+            // From guessadx
+            new CriAdxKey(0x6157, 0x6809, 0x4045),
+
+            // ASCII Media Works 0 (Nogizaka Haruka no Himitsu: Cosplay Hajimemashita)
+            // 2nd from guessadx, other was {0x45ad, 0x5f27, 0x10fd}
+            new CriAdxKey(0x45af, 0x5f27, 0x52b1),
+
+            // D3 Publisher 0 (Little Anchor)
+            // Confirmed unique with guessadx
+            new CriAdxKey(0x5f65, 0x5b3d, 0x5f65),
+
+            // Marvelous 0 (Hanayoi Romanesque: Ai to Kanashimi)
+            // 2nd from guessadx, other was {0x5562, 0x5047, 0x1433}
+            new CriAdxKey(0x5563, 0x5047, 0x43ed),
+
+            // Capcom (Mobile Suit Gundam: Gundam vs. Gundam NEXT PLUS)
+            // Confirmed unique with guessadx
+            new CriAdxKey(0x4f7b, 0x4fdb, 0x5cbf),
+
+            // Developer: Bridge NetShop
+            // Publisher: Kadokawa Shoten (Shoukan Shoujo: Elemental Girl Calling)
+            // Confirmed unique with guessadx
+            new CriAdxKey(0x4f7b, 0x5071, 0x4c61),
+
+            // Developer: Net Corporation
+            // Publisher: Tecmo (Rakushou! Pachi-Slot Sengen 6: Rio 2 Cruising Vanadis)
+            // Confirmed unique with guessadx
+            new CriAdxKey(0x53e9, 0x586d, 0x4eaf),
+
+            // Developer: Aquaplus
+            // Tears to Tiara Gaiden Avalon no Kagi (PS3)
+            // Confirmed unique with guessadx
+            new CriAdxKey(0x47e1, 0x60e9, 0x51c1),
+
+            // Developer: Broccoli
+            // Neon Genesis Evangelion: Koutetsu no Girlfriend 2nd (PS2)
+            // Confirmed unique with guessadx
+            new CriAdxKey(0x481d, 0x4f25, 0x5243),
+
+            // Developer: Marvelous
+            // Futakoi Alternative (PS2)
+            // Confirmed unique with guessadx
+            new CriAdxKey(0x413b, 0x543b, 0x57d1),
+
+            // Developer: Marvelous
+            // Gakuen Utopia - Manabi Straight! KiraKira Happy Festa! (PS2)
+            // 2nd from guessadx, other was {0x440b, 0x4327, 0x564b}
+            new CriAdxKey(0x440d, 0x4327, 0x4fff),
+
+            // Developer: Datam Polystar
+            // Soshite Kono Uchuu ni Kirameku Kimi no Shi XXX (PS2)
+            // Confirmed unique with guessadx
+            new CriAdxKey(0x5f5d, 0x552b, 0x5507),
+
+            // Developer: Sega
+            // Sakura Taisen: Atsuki Chishio Ni (PS2)
+            // Confirmed unique with guessadx
+            new CriAdxKey(0x645d, 0x6011, 0x5c29),
+
+            // Developer: Sega
+            // Sakura Taisen 3 ~Paris wa Moeteiru ka~ (PS2)
+            // Confirmed unique with guessadx
+            new CriAdxKey(0x62ad, 0x4b13, 0x5957),
+
+            // Developer: Jinx
+            // Sotsugyou 2nd Generation (PS2)
+            // 1st from guessadx, other was {0x6307, 0x509f, 0x2ac5}
+            new CriAdxKey(0x6305, 0x509f, 0x4c01),
+
+            // La Corda d'Oro (2005)(-)(Koei)[PSP]
+            // Confirmed unique with guessadx
+            new CriAdxKey(0x55b7, 0x67e5, 0x5387),
+
+            // Nanatsuiro * Drops Pure!! (2007)(Media Works)[PS2]
+            // Confirmed unique with guessadx
+            new CriAdxKey(0x6731, 0x645d, 0x566b),
+
+            // Shakugan no Shana (2006)(Vridge)(Media Works)[PS2]
+            // Confirmed unique with guessadx
+            new CriAdxKey(0x5fc5, 0x63d9, 0x599f),
+
+            // Uragiri wa Boku no Namae o Shitteiru (2010)(Kadokawa Shoten)[PS2]
+            // Confirmed unique with guessadx
+            new CriAdxKey(0x4c73, 0x4d8d, 0x5827),
+
+            // StormLover Kai!! (2012)(D3 Publisher)[PSP]
+            // Confirmed unique with guessadx
+            new CriAdxKey(0x5a11, 0x67e5, 0x6751),
+
+            // Sora no Otoshimono - DokiDoki Summer Vacation (2010)(Kadokawa Shoten)[PSP]
+            // Confirmed unique with guessadx
+            new CriAdxKey(0x5e75, 0x4a89, 0x4c61),
+
+            // Boku wa Koukuu Kanseikan - Airport Hero Naha (2006)(Sonic Powered)(Electronic Arts)[PSP]
+            // Confirmed unique with guessadx
+            new CriAdxKey(0x64ab, 0x5297, 0x632f),
+
+            // Lucky Star - Net Idol Meister (2009)(Kadokawa Shoten)[PSP]
+            // Confirmed unique with guessadx
+            new CriAdxKey(0x4d82, 0x5243, 0x685),
+
+            // Ishin Renka: Ryouma Gaiden (2010-11-25)(-)(D3 Publisher)[PSP]
+            new CriAdxKey(0x54d1, 0x526d, 0x5e8b),
+
+            // Lucky Star - Ryouou Gakuen Outousai Portable (2010-12-22)(-)(Kadokawa Shoten)[PSP]
+            new CriAdxKey(0x4d06, 0x663b, 0x7d09),
+
+            // Marriage Royale - Prism Story (2010-04-28)(-)(ASCII Media Works)[PSP]
+            new CriAdxKey(0x40a9, 0x46b1, 0x62ad),
+
+            // Nogizaka Haruka no Himitsu - Doujinshi Hajime Mashita (2010-10-28)(-)(ASCII Media Works)[PSP]
+            new CriAdxKey(0x4601, 0x671f, 0x0455),
+
+            // Slotter Mania P - Mach Go Go Go III (2011-01-06)(-)(Dorart)[PSP]
+            new CriAdxKey(0x41ef, 0x463d, 0x5507),
+
+            // Nichijou - Uchuujin (2011-07-28)(-)(Kadokawa Shoten)[PSP]
+            new CriAdxKey(0x4369, 0x486d, 0x5461),
+
+            // R-15 Portable (2011-10-27)(-)(Kadokawa Shoten)[PSP]
+            new CriAdxKey(0x6809, 0x5fd5, 0x5bb1),
+
+            // Suzumiya Haruhi-chan no Mahjong (2011-07-07)(-)(Kadokawa Shoten)[PSP]
+            new CriAdxKey(0x5c33, 0x4133, 0x4ce7),
+
+            // Storm Lover Natsu Koi!! (2011-08-04)(Vridge)(D3 Publisher)
+            new CriAdxKey(0x4133, 0x5a01, 0x5723)
+        };
+
+        public static readonly List<CriAdxKey> Keys9 = new List<CriAdxKey>
+        {
+            // Phantasy Star Online 2
+            // Guessed with degod
+            new CriAdxKey(0x07d2, 0x1ec5, 0x0c7f),
+
+            // Dragon Ball Z: Dokkan Battle
+            // Verified by VGAudio
+            new CriAdxKey(416383518),
+
+            // Kisou Ryouhei Gunhound EX (2013-01-31)(Dracue)[PSP]
+            // Verified by VGAudio
+            new CriAdxKey(683461999),
+
+            // Raramagi [Android]
+            // Verified by VGAudio
+            new CriAdxKey(12160794),
+
+            // Sonic runners [Android]
+            // Verified by VGAudio
+            new CriAdxKey(19910623)
+        };
+    }
+}

--- a/src/VGAudio/Codecs/CriAdx/CriAdxKey.cs
+++ b/src/VGAudio/Codecs/CriAdx/CriAdxKey.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using System.Diagnostics;
 using VGAudio.Utilities;
 
 namespace VGAudio.Codecs.CriAdx
 {
+    [DebuggerDisplay("{" + nameof(DebuggerDisplay) + ", nq}")]
     public class CriAdxKey
     {
         public CriAdxKey(int seed, int mult, int inc)
@@ -23,6 +25,7 @@ namespace VGAudio.Codecs.CriAdx
         public CriAdxKey(string keyString)
         {
             if (string.IsNullOrEmpty(keyString)) return;
+            KeyString = keyString;
 
             Seed = Primes[0x100];
             Mult = Primes[0x200];
@@ -39,6 +42,7 @@ namespace VGAudio.Codecs.CriAdx
         public int Seed { get; }
         public int Mult { get; }
         public int Inc { get; }
+        public string KeyString { get; }
         private static int[] Primes { get; } = BuildPrimesTable();
 
         public ulong KeyCode
@@ -60,5 +64,7 @@ namespace VGAudio.Codecs.CriAdx
             Array.Copy(primes, start, trimmedPrimes, 0, 0x400);
             return trimmedPrimes;
         }
+
+        private string DebuggerDisplay => KeyString == null ? $"KeyCode = {KeyCode}" : $"KeyString = \"{KeyString}\"";
     }
 }

--- a/src/VGAudio/Containers/Adx/AdxConfiguration.cs
+++ b/src/VGAudio/Containers/Adx/AdxConfiguration.cs
@@ -1,10 +1,13 @@
-﻿using VGAudio.Formats.CriAdx;
+﻿using VGAudio.Codecs.CriAdx;
+using VGAudio.Formats.CriAdx;
 
 namespace VGAudio.Containers.Adx
 {
     public class AdxConfiguration : Configuration
     {
         public int Version { get; set; } = 4;
+        public int EncryptionType { get; set; }
+        public CriAdxKey EncryptionKey { get; set; }
         public int FrameSize { get; set; } = 18;
         public int Filter { get; set; } = 2;
         public CriAdxType Type { get; set; } = CriAdxType.Linear;

--- a/src/VGAudio/Containers/Adx/AdxReader.cs
+++ b/src/VGAudio/Containers/Adx/AdxReader.cs
@@ -1,4 +1,5 @@
 ﻿using System.IO;
+using VGAudio.Codecs.CriAdx;
 using VGAudio.Formats;
 using VGAudio.Formats.CriAdx;
 using VGAudio.Utilities;
@@ -25,6 +26,7 @@ namespace VGAudio.Containers.Adx
                 {
                     reader.BaseStream.Position = structure.CopyrightOffset + 4;
                     ReadData(reader, structure);
+                    FindKey(structure);
                 }
 
                 return structure;
@@ -33,6 +35,11 @@ namespace VGAudio.Containers.Adx
 
         protected override IAudioFormat ToAudioStream(AdxStructure structure)
         {
+            if (structure.EncryptionKey != null)
+            {
+                CriAdxEncryption.EncryptDecrypt(structure.AudioData, structure.EncryptionKey, structure.VersionMinor, structure.FrameSize);
+            }
+
             var channels = new CriAdxChannel[structure.ChannelCount];
 
             for (int i = 0; i < structure.ChannelCount; i++)
@@ -45,6 +52,18 @@ namespace VGAudio.Containers.Adx
                 .WithAlignmentSamples(structure.AlignmentSamples)
                 .WithEncodingType(structure.EncodingType)
                 .Build();
+        }
+
+        protected override AdxConfiguration GetConfiguration(AdxStructure structure)
+        {
+            var configuration = new AdxConfiguration
+            {
+                FrameSize = structure.FrameSize,
+                Type = structure.EncodingType,
+                EncryptionType = structure.VersionMinor,
+                EncryptionKey = structure.EncryptionKey
+            };
+            return configuration;
         }
 
         private static void ReadHeader(BinaryReader reader, AdxStructure structure)
@@ -100,6 +119,13 @@ namespace VGAudio.Containers.Adx
 
             reader.BaseStream.Position = audioOffset;
             structure.AudioData = reader.BaseStream.DeInterleave(audioSize, structure.FrameSize, structure.ChannelCount);
+        }
+
+        private static void FindKey(AdxStructure structure)
+        {
+            if (structure.VersionMinor == 0) return;
+
+            structure.EncryptionKey = CriAdxEncryption.FindKey(structure.AudioData, structure.VersionMinor, structure.FrameSize);
         }
     }
 }

--- a/src/VGAudio/Containers/Adx/AdxStructure.cs
+++ b/src/VGAudio/Containers/Adx/AdxStructure.cs
@@ -1,4 +1,5 @@
-﻿using VGAudio.Formats.CriAdx;
+﻿using VGAudio.Codecs.CriAdx;
+using VGAudio.Formats.CriAdx;
 using VGAudio.Utilities;
 
 namespace VGAudio.Containers.Adx
@@ -7,6 +8,7 @@ namespace VGAudio.Containers.Adx
     {
         public short CopyrightOffset { get; set; }
         public CriAdxType EncodingType { get; set; }
+        public CriAdxKey EncryptionKey { get; set; }
         public byte FrameSize { get; set; }
         public int SamplesPerFrame => CriAdxHelpers.NibbleCountToSampleCount(FrameSize * 2, FrameSize);
         public byte BitDepth { get; set; }

--- a/src/VGAudio/Containers/Adx/AdxWriter.cs
+++ b/src/VGAudio/Containers/Adx/AdxWriter.cs
@@ -89,7 +89,7 @@ namespace VGAudio.Containers.Adx
             writer.Write(SampleCount);
             writer.Write(Adpcm.Type != CriAdxType.Fixed ? Adpcm.HighpassFrequency : (short)0);
             writer.Write((byte)Version);
-            writer.Write((byte)0); //Minor version
+            writer.Write((byte)Configuration.EncryptionType);
 
             if (Version == 4)
             {
@@ -120,6 +120,14 @@ namespace VGAudio.Containers.Adx
         private void WriteData(BinaryWriter writer)
         {
             byte[][] audio = Adpcm.Channels.Select(x => x.Audio).ToArray();
+
+            if (Configuration.EncryptionKey != null)
+            {
+                // Don't encrypt the original audio
+                audio = audio.Select(x => x.ToArray()).ToArray();
+                CriAdxEncryption.EncryptDecrypt(audio, Configuration.EncryptionKey, Configuration.EncryptionType, FrameSize);
+            }
+
             audio.Interleave(writer.BaseStream, FrameSize, FrameCount * FrameSize);
         }
 

--- a/src/VGAudio/Containers/Wave/WaveReader.cs
+++ b/src/VGAudio/Containers/Wave/WaveReader.cs
@@ -51,7 +51,7 @@ namespace VGAudio.Containers.Wave
                             break;
                     }
 
-                    reader.BaseStream.Position = nextChunkOffset;
+                    reader.BaseStream.Position = nextChunkOffset + (nextChunkOffset & 1); // Wave chunks are 2-byte aligned
                 }
 
                 if (!dataChunkRead)

--- a/src/VGAudio/Containers/Wave/WaveWriter.cs
+++ b/src/VGAudio/Containers/Wave/WaveWriter.cs
@@ -80,6 +80,8 @@ namespace VGAudio.Containers.Wave
 
         private void WriteFmtChunk(BinaryWriter writer)
         {
+            // Every chunk should be 2-byte aligned
+            writer.BaseStream.Position += writer.BaseStream.Position & 1;
             writer.WriteUTF8("fmt ");
             writer.Write(FmtChunkSize);
             writer.Write((short)(ChannelCount > 2 ? WAVE_FORMAT_EXTENSIBLE : WAVE_FORMAT_PCM));
@@ -100,6 +102,7 @@ namespace VGAudio.Containers.Wave
 
         private void WriteDataChunk(BinaryWriter writer)
         {
+            writer.BaseStream.Position += writer.BaseStream.Position & 1;
             writer.WriteUTF8("data");
             writer.Write(DataChunkSize);
 
@@ -117,6 +120,7 @@ namespace VGAudio.Containers.Wave
 
         private void WriteSmplChunk(BinaryWriter writer)
         {
+            writer.BaseStream.Position += writer.BaseStream.Position & 1;
             writer.WriteUTF8("smpl");
             writer.Write(SmplChunkSize);
             for (int i = 0; i < 7; i++)


### PR DESCRIPTION
Adds support for reading and writing encrypted ADX files.
Add all ADX keys from VGMStream.
Encryption keys can either be a key string for type 8 encryption, or a key code for type 9 encryption.
Fixed an issue resulting from unaligned WAVE files.