### PR TITLE
Update to .NET Core 2.0 Runtime and tooling

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -31,7 +31,7 @@ Param(
     [string[]]$ScriptArgs
 )
 
-$dotnetCliVersion = "1.0.4"
+$dotnetCliVersion = "2.0.0"
 
 # Define directories.
 $basePath = Split-Path $MyInvocation.MyCommand.Path -Parent
@@ -108,7 +108,7 @@ try {
 
     Write-Output "Running build..."
 	& dotnet publish /v:q /nologo
-    & dotnet bin/Debug/netcoreapp1.1/publish/Build.dll $Arguments
+    & dotnet bin/Debug/netcoreapp2.0/publish/Build.dll $Arguments
     exit $LASTEXITCODE;
 
 } finally {

--- a/build.ps1
+++ b/build.ps1
@@ -38,7 +38,7 @@ $basePath = Split-Path $MyInvocation.MyCommand.Path -Parent
 $buildPath = Join-Path $basePath "build"
 $dotnetPath = Join-Path $basePath "tools/dotnet"
 $dotnetCliPath = Join-Path $dotnetPath "cli"
-$globalJsonFile = Join-Path $buildPath global.json
+$globalJsonFile = Join-Path $basePath global.json
 
 ###########################################################################
 # INSTALL .NET CORE CLI

--- a/build.sh
+++ b/build.sh
@@ -33,7 +33,7 @@ basePath=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 buildPath=$basePath/build
 dotnetPath=$basePath/tools/dotnet
 dotnetCliPath=$dotnetPath/cli
-globalJsonFile=$buildPath/global.json
+globalJsonFile=$basePath/global.json
 
 trap "rm -f $globalJsonFile" INT TERM EXIT
 

--- a/build.sh
+++ b/build.sh
@@ -26,7 +26,7 @@ while (($#)); do
     shift
 done
 
-dotnetCliVersion="1.0.4"
+dotnetCliVersion="2.0.0"
 
 # Define directories.
 basePath=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
@@ -90,5 +90,5 @@ fi
 
 echo "Running build..."
 dotnet publish /v:q /nologo
-dotnet bin/Debug/netcoreapp1.1/publish/Build.dll --verbosity="$VERBOSITY" --configuration="$CONFIGURATION" --target="$TARGET" $DRYRUN "${SCRIPT_ARGUMENTS[@]}"
+dotnet bin/Debug/netcoreapp2.0/publish/Build.dll --verbosity="$VERBOSITY" --configuration="$CONFIGURATION" --target="$TARGET" $DRYRUN "${SCRIPT_ARGUMENTS[@]}"
 exit $?

--- a/build/Build.csproj
+++ b/build/Build.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp1.1</TargetFramework>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Cake.Frosting" Version="0.1.0-alpha0071" />
     <PackageReference Include="Cake.Common" Version="0.21.1" />
     <PackageReference Include="ConsoleTables" Version="2.1.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.3.0" />
+    <PackageReference Include="ILRepack.Lib" Version="2.0.13" />
   </ItemGroup>
 
 </Project>

--- a/build/Build.csproj
+++ b/build/Build.csproj
@@ -9,7 +9,7 @@
     <PackageReference Include="Cake.Frosting" Version="0.1.0-alpha0071" />
     <PackageReference Include="Cake.Common" Version="0.21.1" />
     <PackageReference Include="ConsoleTables" Version="2.1.0" />
-    <PackageReference Include="ILRepack.Lib" Version="2.0.13" />
+    <PackageReference Include="ILRepack.Lib" Version="2.0.13" NoWarn="NU1701" />
   </ItemGroup>
 
 </Project>

--- a/build/Context.cs
+++ b/build/Context.cs
@@ -50,7 +50,7 @@ namespace Build
 
         public Dictionary<string, LibraryBuildStatus> LibBuilds { get; } = new Dictionary<string, LibraryBuildStatus>
         {
-            ["core"] = new LibraryBuildStatus("netstandard1.1", "netcoreapp1.1", "netcoreapp1.1", "netcoreapp1.1"),
+            ["core"] = new LibraryBuildStatus("netstandard1.1", "netcoreapp2.0", "netcoreapp2.0", "netcoreapp2.0"),
             ["full"] = new LibraryBuildStatus("net45", "net451", "net451", "net46")
         };
 

--- a/build/Tasks/Publish.cs
+++ b/build/Tasks/Publish.cs
@@ -6,10 +6,10 @@ using Cake.Common.IO;
 using Cake.Common.Tools.DotNetCore;
 using Cake.Common.Tools.DotNetCore.Pack;
 using Cake.Common.Tools.DotNetCore.Publish;
-using Cake.Common.Tools.ILRepack;
 using Cake.Core;
 using Cake.Core.IO;
 using Cake.Frosting;
+using ILRepacking;
 using static Build.Utilities;
 
 namespace Build.Tasks
@@ -90,13 +90,22 @@ namespace Build.Tasks
     }
 
     [Dependency(typeof(PublishCli))]
-    [Dependency(typeof(RestoreCakeTools))]
     public sealed class IlRepackCli : FrostingTask<Context>
     {
-        public override void Run(Context context) => context.ILRepack(
-            context.CliBinDir.CombineWithFilePath("VGAudioCli.exe"),
-            context.CliBinDir.CombineWithFilePath($"{context.LibBuilds["full"].CliFramework}/VGAudioCli.exe"),
-            new[] { context.CliBinDir.CombineWithFilePath($"{context.LibBuilds["full"].CliFramework}/VGAudio.dll") });
+        public override void Run(Context context)
+        {
+            RepackOptions options = new RepackOptions
+            {
+                OutputFile = context.CliBinDir.CombineWithFilePath("VGAudioCli.exe").FullPath,
+                InputAssemblies = new[]
+                {
+                    context.CliBinDir.CombineWithFilePath($"{context.LibBuilds["full"].CliFramework}/VGAudioCli.exe").FullPath,
+                    context.CliBinDir.CombineWithFilePath($"{context.LibBuilds["full"].CliFramework}/VGAudio.dll").FullPath
+                },
+                SearchDirectories = new[] { "." }
+            };
+            new ILRepack(options).Repack();
+        }
 
         public override bool ShouldRun(Context context) =>
             context.LibBuilds["full"].CliSuccess == true;
@@ -106,13 +115,22 @@ namespace Build.Tasks
     }
 
     [Dependency(typeof(PublishTools))]
-    [Dependency(typeof(RestoreCakeTools))]
     public sealed class IlRepackTools : FrostingTask<Context>
     {
-        public override void Run(Context context) => context.ILRepack(
-            context.CliBinDir.CombineWithFilePath("VGAudioTools.exe"),
-            context.CliBinDir.CombineWithFilePath($"{context.LibBuilds["full"].ToolsFramework}/VGAudioTools.exe"),
-            new[] { context.CliBinDir.CombineWithFilePath($"{context.LibBuilds["full"].ToolsFramework}/VGAudio.dll") });
+        public override void Run(Context context)
+        {
+            RepackOptions options = new RepackOptions
+            {
+                OutputFile = context.CliBinDir.CombineWithFilePath("VGAudioTools.exe").FullPath,
+                InputAssemblies = new[]
+                {
+                    context.CliBinDir.CombineWithFilePath($"{context.LibBuilds["full"].ToolsFramework}/VGAudioTools.exe").FullPath,
+                    context.CliBinDir.CombineWithFilePath($"{context.LibBuilds["full"].ToolsFramework}/VGAudio.dll").FullPath
+                },
+                SearchDirectories = new[] { "." }
+            };
+            new ILRepack(options).Repack();
+        }
 
         public override bool ShouldRun(Context context) =>
             context.LibBuilds["full"].ToolsSuccess == true;

--- a/build/Tools.xml
+++ b/build/Tools.xml
@@ -1,4 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+ <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="ILRepack" Version="2.0.13" />
   </ItemGroup>

--- a/src/VGAudio.Benchmark/VGAudio.Benchmark.csproj
+++ b/src/VGAudio.Benchmark/VGAudio.Benchmark.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>2.0.0-beta4</VersionPrefix>
-    <TargetFrameworks>netcoreapp1.1;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/src/VGAudio.Cli/VGAudio.Cli.csproj
+++ b/src/VGAudio.Cli/VGAudio.Cli.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net451</TargetFrameworks>
     <OutputType>Exe</OutputType>
 
     <AssemblyName>VGAudioCli</AssemblyName>

--- a/src/VGAudio.Tests/VGAudio.Tests.csproj
+++ b/src/VGAudio.Tests/VGAudio.Tests.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <VersionPrefix>2.0.0-beta4</VersionPrefix>
-    <TargetFrameworks>netcoreapp1.1;net46</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
-    <PackageReference Include="System.ValueTuple" Version="4.3.1" />
+    <PackageReference Condition=" '$(TargetFramework)' == 'net46' " Include="System.ValueTuple" Version="4.4.0" />
     <PackageReference Include="xunit" Version="2.3.0-beta3-build3705" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta3-build3705" />

--- a/src/VGAudio.Tools/VGAudio.Tools.csproj
+++ b/src/VGAudio.Tools/VGAudio.Tools.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net451</TargetFrameworks>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
 	
 	<AssemblyName>VGAudioTools</AssemblyName>

--- a/src/global.json
+++ b/src/global.json
@@ -1,6 +1,6 @@
 ﻿{
   "projects": [ "VGAudio", "VGAudio.Cli", "VGAudio.Tests", "VGAudio.Tools", "VGAudio.Benchmark" ],
   "sdk": {
-    "version": "1.0.4"
+    "version": "2.0.0"
   }
 }

--- a/tools/dotnet/dotnet-install.ps1
+++ b/tools/dotnet/dotnet-install.ps1
@@ -10,18 +10,22 @@
     Installs dotnet cli. If dotnet installation already exists in the given directory
     it will update it only if the requested version differs from the one already installed.
 .PARAMETER Channel
-    Default: preview
-    Channel is the way of reasoning about stability and quality of dotnet. This parameter takes one of the values:
-    - future - Possibly unstable, frequently changing, may contain new finished and unfinished features
-    - preview - Pre-release stable with known issues and feature gaps
-    - production - Most stable releases
+    Default: LTS
+    Download from the Channel specified. Possible values:
+    - Current - most current release
+    - LTS - most current supported release
+    - 2-part version in a format A.B - represents a specific release
+          examples: 2.0; 1.0
+    - Branch name
+          examples: release/2.0.0; Master
 .PARAMETER Version
     Default: latest
     Represents a build version on specific channel. Possible values:
-    - 4-part version in a format A.B.C.D - represents specific version of build
     - latest - most latest build on specific channel
-    - lkg - last known good version on specific channel
-    Note: LKG work is in progress. Once the work is finished, this will become new default
+    - coherent - most latest coherent build on specific channel
+          coherent applies only to SDK downloads
+    - 3-part version in a format A.B.C - represents specific version of build
+          examples: 2.0.0-preview2-006120; 1.1.0
 .PARAMETER InstallDir
     Default: %LocalAppData%\Microsoft\dotnet
     Path to where to install dotnet. Note that binaries will be placed directly in a given directory.
@@ -32,8 +36,6 @@
 .PARAMETER SharedRuntime
     Default: false
     Installs just the shared runtime bits, not the entire SDK
-.PARAMETER DebugSymbols
-    If set the installer will include symbols in the installation.
 .PARAMETER DryRun
     If set it will not perform installation but instead display what command line to use to consistently install
     currently requested version of dotnet cli. In example if you specify version 'latest' it will display a link
@@ -46,23 +48,34 @@
     Displays diagnostics information.
 .PARAMETER AzureFeed
     Default: https://dotnetcli.azureedge.net/dotnet
-    This parameter should not be usually changed by user. It allows to change URL for the Azure feed used by this installer.
+    This parameter typically is not changed by the user.
+    It allows to change URL for the Azure feed used by this installer.
+.PARAMETER UncachedFeed
+    This parameter typically is not changed by the user.
+    It allows to change URL for the Uncached feed used by this installer.
 .PARAMETER ProxyAddress
     If set, the installer will use the proxy when making web requests
+.PARAMETER ProxyUseDefaultCredentials
+    Default: false
+    Use default credentials, when using proxy address.
+.PARAMETER SkipNonVersionedFiles
+    Default: false
+    Skips installing non-versioned files if they already exist, such as dotnet.exe.
 #>
 [cmdletbinding()]
 param(
-   [string]$Channel="rel-1.0.0",
+   [string]$Channel="LTS",
    [string]$Version="Latest",
    [string]$InstallDir="<auto>",
    [string]$Architecture="<auto>",
    [switch]$SharedRuntime,
-   [switch]$DebugSymbols, # TODO: Switch does not work yet. Symbols zip is not being uploaded yet.
    [switch]$DryRun,
    [switch]$NoPath,
    [string]$AzureFeed="https://dotnetcli.azureedge.net/dotnet",
    [string]$UncachedFeed="https://dotnetcli.blob.core.windows.net/dotnet",
-   [string]$ProxyAddress
+   [string]$ProxyAddress,
+   [switch]$ProxyUseDefaultCredentials,
+   [switch]$SkipNonVersionedFiles
 )
 
 Set-StrictMode -Version Latest
@@ -73,7 +86,7 @@ $BinFolderRelativePath=""
 
 # example path with regex: shared/1.0.0-beta-12345/somepath
 $VersionRegEx="/\d+\.\d+[^/]+/"
-$OverrideNonVersionedFiles=$true
+$OverrideNonVersionedFiles = !$SkipNonVersionedFiles
 
 function Say($str) {
     Write-Host "dotnet-install: $str"
@@ -87,6 +100,25 @@ function Say-Invocation($Invocation) {
     $command = $Invocation.MyCommand;
     $args = (($Invocation.BoundParameters.Keys | foreach { "-$_ `"$($Invocation.BoundParameters[$_])`"" }) -join " ")
     Say-Verbose "$command $args"
+}
+
+function Invoke-With-Retry([ScriptBlock]$ScriptBlock, [int]$MaxAttempts = 3, [int]$SecondsBetweenAttempts = 1) {
+    $Attempts = 0
+
+    while ($true) {
+        try {
+            return $ScriptBlock.Invoke()
+        }
+        catch {
+            $Attempts++
+            if ($Attempts -lt $MaxAttempts) {
+                Start-Sleep $SecondsBetweenAttempts
+            }
+            else {
+                throw
+            }
+        }
+    }
 }
 
 function Get-Machine-Architecture() {
@@ -131,61 +163,82 @@ function Load-Assembly([string] $Assembly) {
 
 function GetHTTPResponse([Uri] $Uri)
 {
-    $HttpClient = $null
+    Invoke-With-Retry(
+    {
 
-    try {
-        # HttpClient is used vs Invoke-WebRequest in order to support Nano Server which doesn't support the Invoke-WebRequest cmdlet.
-        Load-Assembly -Assembly System.Net.Http
-        if($ProxyAddress){
-            $HttpClientHandler = New-Object System.Net.Http.HttpClientHandler
-            $HttpClientHandler.Proxy =  New-Object System.Net.WebProxy -Property @{Address=$ProxyAddress}
-            $HttpClient = New-Object System.Net.Http.HttpClient -ArgumentList $HttpClientHandler
-        } 
-        else {
-            $HttpClient = New-Object System.Net.Http.HttpClient
-        }
-        # Default timeout for HttpClient is 100s.  For a 50 MB download this assumes 500 KB/s average, any less will time out
-        # 5 minutes allows it to work over much slower connections.
-        $HttpClient.Timeout = New-TimeSpan -Minutes 5 
-        $Response = $HttpClient.GetAsync($Uri).Result
-        if (($Response -eq $null) -or (-not ($Response.IsSuccessStatusCode)))
-        {
-            $ErrorMsg = "Failed to download $Uri."
-            if ($Response -ne $null)
+        $HttpClient = $null
+
+        try {
+            # HttpClient is used vs Invoke-WebRequest in order to support Nano Server which doesn't support the Invoke-WebRequest cmdlet.
+            Load-Assembly -Assembly System.Net.Http
+
+            if(-not $ProxyAddress)
             {
-                $ErrorMsg += "  $Response"
+                # Despite no proxy being explicitly specified, we may still be behind a default proxy
+                $DefaultProxy = [System.Net.WebRequest]::DefaultWebProxy;
+                if($DefaultProxy -and (-not $DefaultProxy.IsBypassed($Uri))){
+                    $ProxyAddress =  $DefaultProxy.GetProxy($Uri).OriginalString
+                    $ProxyUseDefaultCredentials = $true
+                }
             }
 
-            throw $ErrorMsg
-        }
+            if($ProxyAddress){
+                $HttpClientHandler = New-Object System.Net.Http.HttpClientHandler
+                $HttpClientHandler.Proxy =  New-Object System.Net.WebProxy -Property @{Address=$ProxyAddress;UseDefaultCredentials=$ProxyUseDefaultCredentials}
+                $HttpClient = New-Object System.Net.Http.HttpClient -ArgumentList $HttpClientHandler
+            }
+            else {
+                $HttpClient = New-Object System.Net.Http.HttpClient
+            }
+            # Default timeout for HttpClient is 100s.  For a 50 MB download this assumes 500 KB/s average, any less will time out
+            # 10 minutes allows it to work over much slower connections.
+            $HttpClient.Timeout = New-TimeSpan -Minutes 10
+            $Response = $HttpClient.GetAsync($Uri).Result
+            if (($Response -eq $null) -or (-not ($Response.IsSuccessStatusCode)))
+            {
+                $ErrorMsg = "Failed to download $Uri."
+                if ($Response -ne $null)
+                {
+                    $ErrorMsg += "  $Response"
+                }
 
-        return $Response
-    }
-    finally {
-        if ($HttpClient -ne $null) {
-            $HttpClient.Dispose()
+                throw $ErrorMsg
+            }
+
+             return $Response
         }
-    }
+        finally {
+             if ($HttpClient -ne $null) {
+                $HttpClient.Dispose()
+            }
+        }
+    })
 }
 
 
-function Get-Latest-Version-Info([string]$AzureFeed, [string]$AzureChannel, [string]$CLIArchitecture) {
+function Get-Latest-Version-Info([string]$AzureFeed, [string]$Channel, [bool]$Coherent) {
     Say-Invocation $MyInvocation
 
     $VersionFileUrl = $null
     if ($SharedRuntime) {
-        $VersionFileUrl = "$UncachedFeed/$AzureChannel/dnvm/latest.sharedfx.win.$CLIArchitecture.version"
+        $VersionFileUrl = "$UncachedFeed/Runtime/$Channel/latest.version"
     }
     else {
-        $VersionFileUrl = "$UncachedFeed/Sdk/$AzureChannel/latest.version"
+        if ($Coherent) {
+            $VersionFileUrl = "$UncachedFeed/Sdk/$Channel/latest.coherent.version"
+        }
+        else {
+            $VersionFileUrl = "$UncachedFeed/Sdk/$Channel/latest.version"
+        }
     }
-    
+
     $Response = GetHTTPResponse -Uri $VersionFileUrl
     $StringContent = $Response.Content.ReadAsStringAsync().Result
 
     switch ($Response.Content.Headers.ContentType) {
-        { ($_ -eq "application/octet-stream") } { $VersionText = [Text.Encoding]::UTF8.GetString($StringContent) }
+        { ($_ -eq "application/octet-stream") } { $VersionText = $StringContent }
         { ($_ -eq "text/plain") } { $VersionText = $StringContent }
+        { ($_ -eq "text/plain; charset=UTF-8") } { $VersionText = $StringContent }
         default { throw "``$Response.Content.Headers.ContentType`` is an unknown .version file content type." }
     }
 
@@ -194,47 +247,51 @@ function Get-Latest-Version-Info([string]$AzureFeed, [string]$AzureChannel, [str
     return $VersionInfo
 }
 
-# TODO: AzureChannel and Channel should be unified
-function Get-Azure-Channel-From-Channel([string]$Channel) {
-    Say-Invocation $MyInvocation
 
-    # For compatibility with build scripts accept also directly Azure channels names
-    switch ($Channel.ToLower()) {
-        { ($_ -eq "future") -or ($_ -eq "dev") } { return "dev" }
-        { $_ -eq "production" } { throw "Production channel does not exist yet" }
-        default { return $_ }
-    }
-}
-
-function Get-Specific-Version-From-Version([string]$AzureFeed, [string]$AzureChannel, [string]$CLIArchitecture, [string]$Version) {
+function Get-Specific-Version-From-Version([string]$AzureFeed, [string]$Channel, [string]$Version) {
     Say-Invocation $MyInvocation
 
     switch ($Version.ToLower()) {
         { $_ -eq "latest" } {
-            $LatestVersionInfo = Get-Latest-Version-Info -AzureFeed $AzureFeed -AzureChannel $AzureChannel -CLIArchitecture $CLIArchitecture
+            $LatestVersionInfo = Get-Latest-Version-Info -AzureFeed $AzureFeed -Channel $Channel -Coherent $False
             return $LatestVersionInfo.Version
         }
-        { $_ -eq "lkg" } { throw "``-Version LKG`` not supported yet." }
+        { $_ -eq "coherent" } {
+            $LatestVersionInfo = Get-Latest-Version-Info -AzureFeed $AzureFeed -Channel $Channel -Coherent $True
+            return $LatestVersionInfo.Version
+        }
         default { return $Version }
     }
 }
 
-function Get-Download-Links([string]$AzureFeed, [string]$AzureChannel, [string]$SpecificVersion, [string]$CLIArchitecture) {
+function Get-Download-Link([string]$AzureFeed, [string]$SpecificVersion, [string]$CLIArchitecture) {
     Say-Invocation $MyInvocation
-    
-    $ret = @()
-    
+
     if ($SharedRuntime) {
-        $PayloadURL = "$AzureFeed/$AzureChannel/Binaries/$SpecificVersion/dotnet-win-$CLIArchitecture.$SpecificVersion.zip"
+        $PayloadURL = "$AzureFeed/Runtime/$SpecificVersion/dotnet-runtime-$SpecificVersion-win-$CLIArchitecture.zip"
+    }
+    else {
+        $PayloadURL = "$AzureFeed/Sdk/$SpecificVersion/dotnet-sdk-$SpecificVersion-win-$CLIArchitecture.zip"
+    }
+
+    Say-Verbose "Constructed primary payload URL: $PayloadURL"
+
+    return $PayloadURL
+}
+
+function Get-LegacyDownload-Link([string]$AzureFeed, [string]$SpecificVersion, [string]$CLIArchitecture) {
+    Say-Invocation $MyInvocation
+
+    if ($SharedRuntime) {
+        $PayloadURL = "$AzureFeed/Runtime/$SpecificVersion/dotnet-win-$CLIArchitecture.$SpecificVersion.zip"
     }
     else {
         $PayloadURL = "$AzureFeed/Sdk/$SpecificVersion/dotnet-dev-win-$CLIArchitecture.$SpecificVersion.zip"
     }
 
-    Say-Verbose "Constructed payload URL: $PayloadURL"
-    $ret += $PayloadURL
+    Say-Verbose "Constructed legacy payload URL: $PayloadURL"
 
-    return $ret
+    return $PayloadURL
 }
 
 function Get-User-Share-Path() {
@@ -261,7 +318,7 @@ function Get-Version-Info-From-Version-File([string]$InstallRoot, [string]$Relat
 
     $VersionFile = Join-Path -Path $InstallRoot -ChildPath $RelativePathToVersionFile
     Say-Verbose "Local version file: $VersionFile"
-    
+
     if (Test-Path $VersionFile) {
         $VersionText = cat $VersionFile
         Say-Verbose "Local version file text: $VersionText"
@@ -275,7 +332,7 @@ function Get-Version-Info-From-Version-File([string]$InstallRoot, [string]$Relat
 
 function Is-Dotnet-Package-Installed([string]$InstallRoot, [string]$RelativePathToPackage, [string]$SpecificVersion) {
     Say-Invocation $MyInvocation
-    
+
     $DotnetPackagePath = Join-Path -Path $InstallRoot -ChildPath $RelativePathToPackage | Join-Path -ChildPath $SpecificVersion
     Say-Verbose "Is-Dotnet-Package-Installed: Path to a package: $DotnetPackagePath"
     return Test-Path $DotnetPackagePath -PathType Container
@@ -293,13 +350,13 @@ function Get-Path-Prefix-With-Version($path) {
     if ($match.Success) {
         return $entry.FullName.Substring(0, $match.Index + $match.Length)
     }
-    
+
     return $null
 }
 
 function Get-List-Of-Directories-And-Versions-To-Unpack-From-Dotnet-Package([System.IO.Compression.ZipArchive]$Zip, [string]$OutPath) {
     Say-Invocation $MyInvocation
-    
+
     $ret = @()
     foreach ($entry in $Zip.Entries) {
         $dir = Get-Path-Prefix-With-Version $entry.FullName
@@ -310,12 +367,12 @@ function Get-List-Of-Directories-And-Versions-To-Unpack-From-Dotnet-Package([Sys
             }
         }
     }
-    
+
     $ret = $ret | Sort-Object | Get-Unique
-    
+
     $values = ($ret | foreach { "$_" }) -join ";"
     Say-Verbose "Directories to unpack: $values"
-    
+
     return $ret
 }
 
@@ -339,9 +396,9 @@ function Extract-Dotnet-Package([string]$ZipPath, [string]$OutPath) {
     Set-Variable -Name Zip
     try {
         $Zip = [System.IO.Compression.ZipFile]::OpenRead($ZipPath)
-        
+
         $DirectoriesToUnpack = Get-List-Of-Directories-And-Versions-To-Unpack-From-Dotnet-Package -Zip $Zip -OutPath $OutPath
-        
+
         foreach ($entry in $Zip.Entries) {
             $PathWithVersion = Get-Path-Prefix-With-Version $entry.FullName
             if (($PathWithVersion -eq $null) -Or ($DirectoriesToUnpack -contains $PathWithVersion)) {
@@ -390,17 +447,16 @@ function Prepend-Sdk-InstallRoot-To-Path([string]$InstallRoot, [string]$BinFolde
     }
 }
 
-$AzureChannel = Get-Azure-Channel-From-Channel -Channel $Channel
 $CLIArchitecture = Get-CLIArchitecture-From-Architecture $Architecture
-$SpecificVersion = Get-Specific-Version-From-Version -AzureFeed $AzureFeed -AzureChannel $AzureChannel -CLIArchitecture $CLIArchitecture -Version $Version
-$DownloadLinks = Get-Download-Links -AzureFeed $AzureFeed -AzureChannel $AzureChannel -SpecificVersion $SpecificVersion -CLIArchitecture $CLIArchitecture
+$SpecificVersion = Get-Specific-Version-From-Version -AzureFeed $AzureFeed -Channel $Channel -Version $Version
+$DownloadLink = Get-Download-Link -AzureFeed $AzureFeed -SpecificVersion $SpecificVersion -CLIArchitecture $CLIArchitecture
+$LegacyDownloadLink = Get-LegacyDownload-Link -AzureFeed $AzureFeed -SpecificVersion $SpecificVersion -CLIArchitecture $CLIArchitecture
 
 if ($DryRun) {
     Say "Payload URLs:"
-    foreach ($DownloadLink in $DownloadLinks) {
-        Say "- $DownloadLink"
-    }
-    Say "Repeatable invocation: .\$($MyInvocation.MyCommand) -Version $SpecificVersion -Channel $Channel -Architecture $CLIArchitecture -InstallDir $InstallDir"
+    Say "Primary - $DownloadLink"
+    Say "Legacy - $LegacyDownloadLink"
+    Say "Repeatable invocation: .\$($MyInvocation.Line)"
     exit 0
 }
 
@@ -417,22 +473,32 @@ if ($IsSdkInstalled) {
 
 New-Item -ItemType Directory -Force -Path $InstallRoot | Out-Null
 
-$free = Get-CimInstance -Class win32_logicaldisk | where Deviceid -eq "$((Get-Item $InstallRoot).PSDrive.Name):"
-if ($free.Freespace / 1MB -le 250 ) {
-    Say "there is not enough disk space on drive c:"
+$installDrive = $((Get-Item $InstallRoot).PSDrive.Name);
+$free = Get-CimInstance -Class win32_logicaldisk | where Deviceid -eq "${installDrive}:"
+if ($free.Freespace / 1MB -le 100 ) {
+    Say "There is not enough disk space on drive ${installDrive}:"
     exit 0
 }
 
-foreach ($DownloadLink in $DownloadLinks) {
-    $ZipPath = [System.IO.Path]::GetTempFileName()
-    Say "Downloading $DownloadLink"
+$ZipPath = [System.IO.Path]::combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
+Say-Verbose "Zip path: $ZipPath"
+Say "Downloading link: $DownloadLink"
+try {
     DownloadFile -Uri $DownloadLink -OutPath $ZipPath
-
-    Say "Extracting zip from $DownloadLink"
-    Extract-Dotnet-Package -ZipPath $ZipPath -OutPath $InstallRoot
-
-    Remove-Item $ZipPath
 }
+catch {
+    Say "Cannot download: $DownloadLink"
+    $DownloadLink = $LegacyDownloadLink
+    $ZipPath = [System.IO.Path]::combine([System.IO.Path]::GetTempPath(), [System.IO.Path]::GetRandomFileName())
+    Say-Verbose "Legacy zip path: $ZipPath"
+    Say "Downloading legacy link: $DownloadLink"
+    DownloadFile -Uri $DownloadLink -OutPath $ZipPath
+}
+
+Say "Extracting zip from $DownloadLink"
+Extract-Dotnet-Package -ZipPath $ZipPath -OutPath $InstallRoot
+
+Remove-Item $ZipPath
 
 Prepend-Sdk-InstallRoot-To-Path -InstallRoot $InstallRoot -BinFolderRelativePath $BinFolderRelativePath
 

--- a/tools/dotnet/dotnet-install.sh
+++ b/tools/dotnet/dotnet-install.sh
@@ -1,8 +1,7 @@
+#!/usr/bin/env bash
 # Copyright (c) .NET Foundation and contributors. All rights reserved.
 # Licensed under the MIT license. See LICENSE file in the project root for full license information.
 #
-
-# Note: This script should be compatible with the dash shell used in Ubuntu. So avoid bashisms! See https://wiki.ubuntu.com/DashAsBinSh for more info
 
 # Stop script on NZEC
 set -e
@@ -113,10 +112,25 @@ get_current_os_name() {
     eval $invocation
 
     local uname=$(uname)
-    if [ "$linux_portable" = true ]; then
-        echo "linux"
+    if [ "$uname" = "Darwin" ]; then
+        echo "osx"
         return 0
-    elif [ "$uname" = "Darwin" ]; then
+    else
+        if [ "$uname" = "Linux" ]; then
+            echo "linux"
+            return 0
+        fi
+    fi
+    
+    say_err "OS name could not be detected: $ID.$VERSION_ID"
+    return 1
+}
+
+get_distro_specific_os_name() {
+    eval $invocation
+
+    local uname=$(uname)
+    if [ "$uname" = "Darwin" ]; then
         echo "osx"
         return 0
     elif [ -n "$runtime_id" ]; then
@@ -133,7 +147,7 @@ get_current_os_name() {
         fi
     fi
     
-    say_err "OS name could not be detected: $ID.$VERSION_ID"
+    say_verbose "Distribution specific OS name and version could not be detected: $ID.$VERSION_ID"
     return 1
 }
 
@@ -144,12 +158,19 @@ machine_has() {
     return $?
 }
 
+
 check_min_reqs() {
-    if ! machine_has "curl"; then
-        say_err "curl is required to download dotnet. Install curl to proceed."
+    local hasMinimum=false
+    if machine_has "curl"; then
+        hasMinimum=true
+    elif machine_has "wget"; then
+        hasMinimum=true
+    fi
+
+    if [ "$hasMinimum" = "false" ]; then
+        say_err "curl (recommended) or wget are required to download dotnet. Install missing prerequisite to proceed."
         return 1
     fi
-    
     return 0
 }
 
@@ -172,8 +193,8 @@ check_pre_reqs() {
 
         [ -z "$($LDCONFIG_COMMAND -p | grep libunwind)" ] && say_err "Unable to locate libunwind. Install libunwind to continue" && failing=true
         [ -z "$($LDCONFIG_COMMAND -p | grep libssl)" ] && say_err "Unable to locate libssl. Install libssl to continue" && failing=true
-        [ -z "$($LDCONFIG_COMMAND -p | grep libcurl)" ] && say_err "Unable to locate libcurl. Install libcurl to continue" && failing=true
         [ -z "$($LDCONFIG_COMMAND -p | grep libicu)" ] && say_err "Unable to locate libicu. Install libicu to continue" && failing=true
+        [ -z "$($LDCONFIG_COMMAND -p | grep -F libcurl.so)" ] && say_err "Unable to locate libcurl. Install libcurl to continue" && failing=true
     fi
 
     if [ "$failing" = true ]; then
@@ -256,12 +277,12 @@ get_normalized_architecture_from_architecture() {
             return 0
             ;;
         x86)
-            say_err "Architecture ``x86`` currently not supported"
+            say_err "Architecture \`x86\` currently not supported"
             return 1
             ;;
     esac
    
-    say_err "Architecture ``$architecture`` not supported. If you think this is a bug, please report it at https://github.com/dotnet/cli/issues"
+    say_err "Architecture \`$architecture\` not supported. If you think this is a bug, please report it at https://github.com/dotnet/cli/issues"
     return 1
 }
 
@@ -311,23 +332,26 @@ is_dotnet_package_installed() {
 
 # args:
 # azure_feed - $1
-# azure_channel - $2
+# channel - $2
 # normalized_architecture - $3
+# coherent - $4
 get_latest_version_info() {
     eval $invocation
     
     local azure_feed=$1
-    local azure_channel=$2
+    local channel=$2
     local normalized_architecture=$3
-    
-    local osname
-    osname=$(get_current_os_name) || return 1
+    local coherent=$4
 
     local version_file_url=null
     if [ "$shared_runtime" = true ]; then
-        version_file_url="$uncached_feed/$azure_channel/dnvm/latest.sharedfx.$osname.$normalized_architecture.version"
+        version_file_url="$uncached_feed/Runtime/$channel/latest.version"
     else
-        version_file_url="$uncached_feed/Sdk/$azure_channel/latest.version"
+        if [ "$coherent" = true ]; then
+            version_file_url="$uncached_feed/Sdk/$channel/latest.coherent.version"
+        else
+            version_file_url="$uncached_feed/Sdk/$channel/latest.version"
+        fi
     fi
     say_verbose "get_latest_version_info: latest url: $version_file_url"
     
@@ -336,49 +360,32 @@ get_latest_version_info() {
 }
 
 # args:
-# channel - $1
-get_azure_channel_from_channel() {
-    eval $invocation
-    
-    local channel=$(to_lowercase $1)
-    case $channel in
-        future|dev)
-            echo "dev"
-            return 0
-            ;;
-        production)
-            say_err "Production channel does not exist yet"
-            return 1
-    esac
-    
-	echo $channel
-    return 0
-}
-
-# args:
 # azure_feed - $1
-# azure_channel - $2
+# channel - $2
 # normalized_architecture - $3
 # version - $4
 get_specific_version_from_version() {
     eval $invocation
     
     local azure_feed=$1
-    local azure_channel=$2
+    local channel=$2
     local normalized_architecture=$3
     local version=$(to_lowercase $4)
 
     case $version in
         latest)
             local version_info
-	    version_info="$(get_latest_version_info $azure_feed $azure_channel $normalized_architecture)" || return 1
+            version_info="$(get_latest_version_info $azure_feed $channel $normalized_architecture false)" || return 1
             say_verbose "get_specific_version_from_version: version_info=$version_info"
             echo "$version_info" | get_version_from_version_info
             return 0
             ;;
-        lkg)
-            say_err "``--version LKG`` not supported yet."
-            return 1
+        coherent)
+            local version_info
+            version_info="$(get_latest_version_info $azure_feed $channel $normalized_architecture true)" || return 1
+            say_verbose "get_specific_version_from_version: version_info=$version_info"
+            echo "$version_info" | get_version_from_version_info
+            return 0
             ;;
         *)
             echo $version
@@ -389,28 +396,55 @@ get_specific_version_from_version() {
 
 # args:
 # azure_feed - $1
-# azure_channel - $2
+# channel - $2
 # normalized_architecture - $3
 # specific_version - $4
 construct_download_link() {
     eval $invocation
     
     local azure_feed=$1
-    local azure_channel=$2
+    local channel=$2
     local normalized_architecture=$3
     local specific_version=${4//[$'\t\r\n']}
     
     local osname
     osname=$(get_current_os_name) || return 1
-    
+
     local download_link=null
     if [ "$shared_runtime" = true ]; then
-        download_link="$azure_feed/$azure_channel/Binaries/$specific_version/dotnet-$osname-$normalized_architecture.$specific_version.tar.gz"
+        download_link="$azure_feed/Runtime/$specific_version/dotnet-runtime-$specific_version-$osname-$normalized_architecture.tar.gz"
     else
-        download_link="$azure_feed/Sdk/$specific_version/dotnet-dev-$osname-$normalized_architecture.$specific_version.tar.gz"
+        download_link="$azure_feed/Sdk/$specific_version/dotnet-sdk-$specific_version-$osname-$normalized_architecture.tar.gz"
     fi
     
     echo "$download_link"
+    return 0
+}
+
+# args:
+# azure_feed - $1
+# channel - $2
+# normalized_architecture - $3
+# specific_version - $4
+construct_legacy_download_link() {
+    eval $invocation
+    
+    local azure_feed=$1
+    local channel=$2
+    local normalized_architecture=$3
+    local specific_version=${4//[$'\t\r\n']}
+
+    local distro_specific_osname
+    distro_specific_osname=$(get_distro_specific_os_name) || return 1
+
+    local legacy_download_link=null
+    if [ "$shared_runtime" = true ]; then
+        legacy_download_link="$azure_feed/Runtime/$specific_version/dotnet-$distro_specific_osname-$normalized_architecture.$specific_version.tar.gz"
+    else
+        legacy_download_link="$azure_feed/Sdk/$specific_version/dotnet-dev-$distro_specific_osname-$normalized_architecture.$specific_version.tar.gz"
+    fi
+
+    echo "$legacy_download_link"
     return 0
 }
 
@@ -509,7 +543,7 @@ extract_dotnet_package() {
     
     local folders_with_version_regex='^.*/[0-9]+\.[0-9]+[^/]+/'
     find $temp_out_path -type f | grep -Eo $folders_with_version_regex | copy_files_or_dirs_from_list $temp_out_path $out_path false
-    find $temp_out_path -type f | grep -Ev $folders_with_version_regex | copy_files_or_dirs_from_list $temp_out_path $out_path true
+    find $temp_out_path -type f | grep -Ev $folders_with_version_regex | copy_files_or_dirs_from_list $temp_out_path $out_path $override_non_versioned_files
     
     rm -rf $temp_out_path
     
@@ -524,49 +558,94 @@ extract_dotnet_package() {
 # [out_path] - $2 - stdout if not provided
 download() {
     eval $invocation
-    
+
+    local remote_path=$1
+    local out_path=${2:-}
+
+    local failed=false
+    if machine_has "curl"; then
+        downloadcurl $remote_path $out_path || failed=true
+    elif machine_has "wget"; then
+        downloadwget $remote_path $out_path || failed=true
+    else
+        failed=true
+    fi
+    if [ "$failed" = true ]; then
+        say_verbose "Download failed: $remote_path"
+        return 1
+    fi
+    return 0
+}
+
+downloadcurl() {
+    eval $invocation
     local remote_path=$1
     local out_path=${2:-}
 
     local failed=false
     if [ -z "$out_path" ]; then
-        curl --fail -s $remote_path || failed=true
+        curl --retry 10 -sSL -f --create-dirs $remote_path || failed=true
     else
-        curl --fail -s -o $out_path $remote_path || failed=true
+        curl --retry 10 -sSL -f --create-dirs -o $out_path $remote_path || failed=true
     fi
-    
     if [ "$failed" = true ]; then
-        say_err "Download failed"
+        say_verbose "Curl download failed"
         return 1
     fi
+    return 0
+}
+
+downloadwget() {
+    eval $invocation
+    local remote_path=$1
+    local out_path=${2:-}
+
+    local failed=false
+    if [ -z "$out_path" ]; then
+        wget -q --tries 10 -O - $remote_path || failed=true
+    else
+        wget -v --tries 10 -O $out_path $remote_path || failed=true
+    fi
+    if [ "$failed" = true ]; then
+        say_verbose "Wget download failed"
+        return 1
+    fi
+    return 0
 }
 
 calculate_vars() {
     eval $invocation
-    
-    azure_channel=$(get_azure_channel_from_channel "$channel")
-    say_verbose "azure_channel=$azure_channel"
-    
+    valid_legacy_download_link=true
+
     normalized_architecture=$(get_normalized_architecture_from_architecture "$architecture")
     say_verbose "normalized_architecture=$normalized_architecture"
     
-    specific_version=$(get_specific_version_from_version $azure_feed $azure_channel $normalized_architecture $version)
+    specific_version=$(get_specific_version_from_version $azure_feed $channel $normalized_architecture $version)
     say_verbose "specific_version=$specific_version"
     if [ -z "$specific_version" ]; then
         say_err "Could not get version information."
         return 1
     fi
     
-    download_link=$(construct_download_link $azure_feed $azure_channel $normalized_architecture $specific_version)
+    download_link=$(construct_download_link $azure_feed $channel $normalized_architecture $specific_version)
     say_verbose "download_link=$download_link"
-    
+
+    legacy_download_link=$(construct_legacy_download_link $azure_feed $channel $normalized_architecture $specific_version) || valid_legacy_download_link=false
+
+    if [ "$valid_legacy_download_link" = true ]; then
+        say_verbose "legacy_download_link=$legacy_download_link"
+    else
+        say_verbose "Cound not construct a legacy_download_link; omitting..."
+    fi
+
     install_root=$(resolve_installation_path $install_dir)
     say_verbose "install_root=$install_root"
 }
 
 install_dotnet() {
     eval $invocation
-    
+    local download_failed=false
+
     if is_dotnet_package_installed $install_root "sdk" $specific_version; then
         say ".NET SDK version $specific_version is already installed."
         return 0
@@ -575,12 +654,21 @@ install_dotnet() {
     mkdir -p $install_root
     zip_path=$(mktemp $temporary_file_template)
     say_verbose "Zip path: $zip_path"
+
+    say "Downloading link: $download_link"
+    download "$download_link" $zip_path || download_failed=true
+
+    #  if the download fails, download the legacy_download_link
+    if [ "$download_failed" = true ] && [ "$valid_legacy_download_link" = true ]; then
+        say "Cannot download: $download_link"
+        download_link=$legacy_download_link
+        zip_path=$(mktemp $temporary_file_template)
+        say_verbose "Legacy zip path: $zip_path"
+        say "Downloading legacy link: $download_link"
+        download "$download_link" $zip_path
+    fi
     
-    say "Downloading $download_link"
-    download "$download_link" $zip_path
-    say_verbose "Downloaded file exists and readable? $(if [ -r $zip_path ]; then echo "yes"; else echo "no"; fi)"
-    
-    say "Extracting zip"
+    say "Extracting zip from $download_link"
     extract_dotnet_package $zip_path $install_root
     
     return 0
@@ -590,19 +678,18 @@ local_version_file_relative_path="/.version"
 bin_folder_relative_path=""
 temporary_file_template="${TMPDIR:-/tmp}/dotnet.XXXXXXXXX"
 
-channel="rel-1.0.0"
+channel="LTS"
 version="Latest"
 install_dir="<auto>"
 architecture="<auto>"
-debug_symbols=false
 dry_run=false
 no_path=false
 azure_feed="https://dotnetcli.azureedge.net/dotnet"
 uncached_feed="https://dotnetcli.blob.core.windows.net/dotnet"
 verbose=false
 shared_runtime=false
-linux_portable=false
 runtime_id=""
+override_non_versioned_files=true
 
 while [ $# -ne 0 ]
 do
@@ -627,9 +714,6 @@ do
         --shared-runtime|-[Ss]hared[Rr]untime)
             shared_runtime=true
             ;;
-        --debug-symbols|-[Dd]ebug[Ss]ymbols)
-            debug_symbols=true
-            ;;
         --dry-run|-[Dd]ry[Rr]un)
             dry_run=true
             ;;
@@ -643,12 +727,17 @@ do
             shift
             azure_feed="$1"
             ;;
-        --linux-portable|-[Ll]inux[Pp]ortable)
-            linux_portable=true
+        --uncached-feed|-[Uu]ncached[Ff]eed)
+            shift
+            uncached_feed="$1"
             ;;
         --runtime-id|-[Rr]untime[Ii]d)
             shift
             runtime_id="$1"
+            ;;
+        --skip-non-versioned-files|-[Ss]kip[Nn]on[Vv]ersioned[Ff]iles)
+            shift
+            override_non_versioned_files=false
             ;;
         -?|--?|-h|--help|-[Hh]elp)
             script_name="$(basename $0)"
@@ -659,24 +748,37 @@ do
             echo "$script_name is a simple command line interface for obtaining dotnet cli."
             echo ""
             echo "Options:"
-            echo "  -c,--channel <CHANNEL>         Download from the CHANNEL specified (default: $channel)."
+            echo "  -c,--channel <CHANNEL>         Download from the CHANNEL specified, Defaults to \`$channel\`."
             echo "      -Channel"
-            echo "  -v,--version <VERSION>         Use specific version, ``latest`` or ``lkg``. Defaults to ``latest``."
+            echo "          Possible values:"
+            echo "          - Current - most current release"
+            echo "          - LTS - most current supported release"
+            echo "          - 2-part version in a format A.B - represents a specific release"
+            echo "              examples: 2.0; 1.0"
+            echo "          - Branch name"
+            echo "              examples: release/2.0.0; Master"
+            echo "  -v,--version <VERSION>         Use specific VERSION, Defaults to \`$version\`."
             echo "      -Version"
+            echo "          Possible values:"
+            echo "          - latest - most latest build on specific channel"
+            echo "          - coherent - most latest coherent build on specific channel"
+            echo "              coherent applies only to SDK downloads"
+            echo "          - 3-part version in a format A.B.C - represents specific version of build"
+            echo "              examples: 2.0.0-preview2-006120; 1.1.0"
             echo "  -i,--install-dir <DIR>         Install under specified location (see Install Location below)"
             echo "      -InstallDir"
             echo "  --architecture <ARCHITECTURE>  Architecture of .NET Tools. Currently only x64 is supported."
             echo "      --arch,-Architecture,-Arch"
             echo "  --shared-runtime               Installs just the shared runtime bits, not the entire SDK."
             echo "      -SharedRuntime"
-            echo "  --debug-symbols,-DebugSymbols  Specifies if symbols should be included in the installation."
+            echo "  --skip-non-versioned-files     Skips non-versioned files if they already exist, such as the dotnet executable."
+            echo "      -SkipNonVersionedFiles"
             echo "  --dry-run,-DryRun              Do not perform installation. Display download link."
             echo "  --no-path, -NoPath             Do not set PATH for the current process."
             echo "  --verbose,-Verbose             Display diagnostics information."
-            echo "  --azure-feed,-AzureFeed        Azure feed location. Defaults to $azure_feed"
-            echo "  --linux-portable               Installs the Linux portable .NET Tools instead of a distro-specific version."
-            echo "      -LinuxPortable"
-            echo "  --runtime-id                   Installs the .NET Tools for the given platform (such as linux-x64)."
+            echo "  --azure-feed,-AzureFeed        Azure feed location. Defaults to $azure_feed, This parameter typically is not changed by the user."
+            echo "  --uncached-feed,-UncachedFeed  Uncached feed location. This parameter typically is not changed by the user."
+            echo "  --runtime-id                   Installs the .NET Tools for the given platform (use linux-x64 for portable linux)."
             echo "      -RuntimeId"
             echo "  -?,--?,-h,--help,-Help         Shows this help message"
             echo ""
@@ -698,8 +800,12 @@ done
 
 check_min_reqs
 calculate_vars
+
 if [ "$dry_run" = true ]; then
     say "Payload URL: $download_link"
+    if [ "$valid_legacy_download_link" = true ]; then
+        say "Legacy payload URL: $legacy_download_link"
+    fi
     say "Repeatable invocation: ./$(basename $0) --version $specific_version --channel $channel --install-dir $install_dir"
     exit 0
 fi
@@ -709,7 +815,7 @@ install_dotnet
 
 bin_path=$(get_absolute_path $(combine_paths $install_root $bin_folder_relative_path))
 if [ "$no_path" = false ]; then
-    say "Adding to current process PATH: ``$bin_path``. Note: This change will be visible only when sourcing script."
+    say "Adding to current process PATH: \`$bin_path\`. Note: This change will be visible only when sourcing script."
     export PATH=$bin_path:$PATH
 else
     say "Binaries of dotnet can be found in $bin_path"


### PR DESCRIPTION
- Use .NET Core SDK 2.0
- Target .NET Core 2.0
- Use ILRepack library during build
- Fix issue that placed global.json in the wrong folder during build
- Update dotnet-install scripts