### PR TITLE
Miscellaneous Cleanup

### DIFF
--- a/src/VGAudio.Benchmark/Runner.cs
+++ b/src/VGAudio.Benchmark/Runner.cs
@@ -4,7 +4,7 @@ using BenchmarkDotNet.Horology;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Running;
 using VGAudio.Benchmark.AdpcmBenchmarks;
-using VGAudio.Benchmark.HelperBenchmarks;
+using VGAudio.Benchmark.UtilityBenchmarks;
 
 namespace VGAudio.Benchmark
 {

--- a/src/VGAudio.Benchmark/UtilityBenchmarks/BitReaderBenchmarks.cs
+++ b/src/VGAudio.Benchmark/UtilityBenchmarks/BitReaderBenchmarks.cs
@@ -4,7 +4,7 @@ using BenchmarkDotNet.Attributes;
 using VGAudio.Utilities;
 
 
-namespace VGAudio.Benchmark.HelperBenchmarks
+namespace VGAudio.Benchmark.UtilityBenchmarks
 {
     public class BitReaderBenchmarks
     {

--- a/src/VGAudio.Benchmark/UtilityBenchmarks/BitReaderBenchmarks.cs
+++ b/src/VGAudio.Benchmark/UtilityBenchmarks/BitReaderBenchmarks.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using BenchmarkDotNet.Attributes;
 using VGAudio.Utilities;
 
-
 namespace VGAudio.Benchmark.UtilityBenchmarks
 {
     public class BitReaderBenchmarks

--- a/src/VGAudio.Benchmark/UtilityBenchmarks/InterleaveBenchmarks.cs
+++ b/src/VGAudio.Benchmark/UtilityBenchmarks/InterleaveBenchmarks.cs
@@ -2,7 +2,7 @@
 using BenchmarkDotNet.Attributes;
 using VGAudio.Utilities;
 
-namespace VGAudio.Benchmark.HelperBenchmarks
+namespace VGAudio.Benchmark.UtilityBenchmarks
 {
     public class InterleaveBenchmarks
     {

--- a/src/VGAudio.Tests/Equality/AudioFormatComparer.cs
+++ b/src/VGAudio.Tests/Equality/AudioFormatComparer.cs
@@ -10,6 +10,7 @@ namespace VGAudio.Tests.Equality
     {
         public override bool Equals(IAudioFormat x, IAudioFormat y)
         {
+            if (x == null || y == null) return false;
             if (x.GetType() != y.GetType()) return false;
 
             switch (x)

--- a/src/VGAudio.Tests/Formats/GcAdpcm/GcAdpcmAlignmentTests.cs
+++ b/src/VGAudio.Tests/Formats/GcAdpcm/GcAdpcmAlignmentTests.cs
@@ -90,11 +90,11 @@ namespace VGAudio.Tests.Formats.GcAdpcm
         }
 
         [Theory]
-        [InlineData(1000, 4524, 100, 2)]
-        [InlineData(1000, 2012, 1, 2)]
-        [InlineData(1000, 60, 1, 2)]
-        [InlineData(1000, 60, 20, 2)]
-        public void AlignedPcmIsCorrect(int multiple, int loopStart, int sineCycles, int tolerance)
+        [InlineData(1000, 4524, 100)]
+        [InlineData(1000, 2012, 1)]
+        [InlineData(1000, 60, 1)]
+        [InlineData(1000, 60, 20)]
+        public void AlignedPcmIsCorrect(int multiple, int loopStart, int sineCycles)
         {
             int loopEnd = sineCycles * 4 * SamplesPerFrame + loopStart;
             var pcm = GenerateSineWave(GetNextMultiple(loopEnd, SamplesPerFrame), 1, SamplesPerFrame * 4);
@@ -102,7 +102,7 @@ namespace VGAudio.Tests.Formats.GcAdpcm
             var adpcm = GcAdpcmEncoder.Encode(pcm, coefs);
             var alignment = new GcAdpcmAlignment(multiple, loopStart, loopEnd, adpcm, coefs);
             var pcmAligned = alignment.PcmAligned;
-            var pcmExpected = GcAdpcmDecoder.Decode(alignment.AdpcmAligned, coefs, new GcAdpcmParameters{ SampleCount = alignment.SampleCountAligned});
+            var pcmExpected = GcAdpcmDecoder.Decode(alignment.AdpcmAligned, coefs, new GcAdpcmParameters { SampleCount = alignment.SampleCountAligned });
 
             Assert.Equal(pcmExpected, pcmAligned);
         }

--- a/src/VGAudio.Tests/Formats/GcAdpcmFormatBuilderTests.cs
+++ b/src/VGAudio.Tests/Formats/GcAdpcmFormatBuilderTests.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using VGAudio.Formats;
 using VGAudio.Formats.GcAdpcm;
+using VGAudio.Utilities;
 using Xunit;
 using static VGAudio.Codecs.GcAdpcm.GcAdpcmHelpers;
 
@@ -85,7 +86,7 @@ namespace VGAudio.Tests.Formats
                 .WithAlignment(alignment)
                 .WithLoop(looping, loopStart, loopEnd);
 
-            int extraSamples = Utilities.Helpers.GetNextMultiple(loopStart, alignment) - loopStart;
+            int extraSamples = Helpers.GetNextMultiple(loopStart, alignment) - loopStart;
 
             Assert.Equal(SampleCountToByteCount(loopEnd + extraSamples), adpcm.Channels[0].GetAdpcmAudio().Length);
         }
@@ -110,7 +111,7 @@ namespace VGAudio.Tests.Formats
                 .WithAlignment(alignment)
                 .WithLoop(looping, loopStart, loopEnd);
 
-            int extraSamples = Utilities.Helpers.GetNextMultiple(loopStart, alignment) - loopStart;
+            int extraSamples = Helpers.GetNextMultiple(loopStart, alignment) - loopStart;
 
             Assert.Equal(loopStart + extraSamples, adpcm.LoopStart);
             Assert.Equal(loopEnd + extraSamples, adpcm.LoopEnd);

--- a/src/VGAudio.Tests/Utilities/DeinterleaveTests.cs
+++ b/src/VGAudio.Tests/Utilities/DeinterleaveTests.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using Xunit;
 using VGAudio.Utilities;
 
-namespace VGAudio.Tests.Helpers
+namespace VGAudio.Tests.Utilities
 {
     public static class DeinterleaveTests
     {

--- a/src/VGAudio.Tests/Utilities/DeinterleaveTests.cs
+++ b/src/VGAudio.Tests/Utilities/DeinterleaveTests.cs
@@ -2,8 +2,8 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Xunit;
 using VGAudio.Utilities;
+using Xunit;
 
 namespace VGAudio.Tests.Utilities
 {

--- a/src/VGAudio.Tests/Utilities/InterleaveTests.cs
+++ b/src/VGAudio.Tests/Utilities/InterleaveTests.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using Xunit;
 using VGAudio.Utilities;
 
-namespace VGAudio.Tests.Helpers
+namespace VGAudio.Tests.Utilities
 {
     public static class InterleaveTests
     {

--- a/src/VGAudio.Tests/Utilities/MdctTests.cs
+++ b/src/VGAudio.Tests/Utilities/MdctTests.cs
@@ -1,7 +1,7 @@
 ﻿using VGAudio.Utilities;
 using Xunit;
 
-namespace VGAudio.Tests.Helpers
+namespace VGAudio.Tests.Utilities
 {
     public class MdctTests
     {

--- a/src/VGAudio.Tests/Utilities/PreBuiltMdctTables.cs
+++ b/src/VGAudio.Tests/Utilities/PreBuiltMdctTables.cs
@@ -1,4 +1,4 @@
-﻿namespace VGAudio.Tests.Helpers
+﻿namespace VGAudio.Tests.Utilities
 {
     public static class PreBuiltMdctTables
     {

--- a/src/VGAudio.Tests/VGAudio.Tests.csproj
+++ b/src/VGAudio.Tests/VGAudio.Tests.csproj
@@ -8,9 +8,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Condition=" '$(TargetFramework)' == 'net46' " Include="System.ValueTuple" Version="4.4.0" />
-    <PackageReference Include="xunit" Version="2.3.0-beta3-build3705" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta3-build3705" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta3-build3705" />
+    <PackageReference Include="xunit" Version="2.3.0-beta4-build3742" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.0-beta4-build3742" />
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.0-beta4-build3742" />
     <ProjectReference Include="..\VGAudio\VGAudio.csproj" />
   </ItemGroup>
 

--- a/src/VGAudio.Tools/Common.cs
+++ b/src/VGAudio.Tools/Common.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using VGAudio.Containers.Adx;
 using VGAudio.Containers.Dsp;
 using VGAudio.Containers.Genh;
+using VGAudio.Containers.Hca;
 using VGAudio.Containers.Hps;
 using VGAudio.Containers.Idsp;
 using VGAudio.Containers.NintendoWare;
@@ -22,7 +23,8 @@ namespace VGAudio.Tools
             new FileTypeInfo(FileType.Bfstm, "*.bfstm", () => new BCFstmReader(), () => new BCFstmWriter(NwTarget.Cafe)),
             new FileTypeInfo(FileType.Hps, "*.hps", () => new HpsReader(), () => new HpsWriter()),
             new FileTypeInfo(FileType.Adx, "*.adx", () => new AdxReader(), () => new AdxWriter()),
-            new FileTypeInfo(FileType.Genh, "*.genh", () => new GenhReader(), () => null)
+            new FileTypeInfo(FileType.Genh, "*.genh", () => new GenhReader(), null),
+            new FileTypeInfo(FileType.Hca, "*.hca", () => new HcaReader(), null)
         }.ToDictionary(x => x.Type, x => x);
 
         public static int[] GetPrimes(int maxPrime)

--- a/src/VGAudio.Tools/FileType.cs
+++ b/src/VGAudio.Tools/FileType.cs
@@ -14,7 +14,8 @@ namespace VGAudio.Tools
         Bfstm,
         Hps,
         Genh,
-        Adx
+        Adx,
+        Hca
     }
 
     internal class FileTypeInfo

--- a/src/VGAudio.Tools/Parse.cs
+++ b/src/VGAudio.Tools/Parse.cs
@@ -10,7 +10,7 @@ namespace VGAudio.Tools
 
             Console.WriteLine($"{type} is not a valid file type");
             Console.WriteLine("Valid file types are:");
-            Console.WriteLine("Wave, Dsp, Idsp, Brstm, Bcstm, Bfstm, Adx");
+            Console.WriteLine("Wave, Dsp, Idsp, Brstm, Bcstm, Bfstm, Adx, Hca");
             return FileType.NotSet;
         }
     }

--- a/src/VGAudio.Tools/Rebuild/Rebuilder.cs
+++ b/src/VGAudio.Tools/Rebuild/Rebuilder.cs
@@ -40,9 +40,18 @@ namespace VGAudio.Tools.Rebuild
                         a.RecalculateLoopContext = false;
                         a.RecalculateSeekTable = false;
                     }
-                    byte[] outFile = Writer().GetFile(audio.AudioFormat, audio.Configuration);
-                    int diff = Common.DiffArrays(inFile, outFile);
-                    Results[i] = new Result(Files[i], diff);
+
+                    int bytesDiff = 0;
+                    if (Writer != null)
+                    {
+                        byte[] outFile = Writer().GetFile(audio.AudioFormat, audio.Configuration);
+                        bytesDiff = Common.DiffArrays(inFile, outFile);
+                    }
+                    else
+                    {
+                        audio.AudioFormat.ToPcm16();
+                    }
+                    Results[i] = new Result(Files[i], bytesDiff);
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
- Rename test and benchmark Helpers namespace to Utilities
- Add additional methods to BitReader class
- Rebuilder: If there is no encoder for a format, test that the decode runs without error