### PR TITLE
Fix build on HP computers

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -86,6 +86,10 @@ try {
     $originalEnvPath = $env:Path
     SetupDotnetCli
 
+    # HP sets the "Platform" environment variable with some of their software
+    # Clear that to allow the build to work
+    $env:Platform = ""
+
 ###########################################################################
 # RUN BUILD SCRIPT
 ###########################################################################


### PR DESCRIPTION
HP sets the "Platform" environment variable with some of their software. Clear that variable before building to allow the build to work.