### PR TITLE
Add more options to VGAudioCli

### DIFF
--- a/src/VGAudio.Cli/CliArguments.cs
+++ b/src/VGAudio.Cli/CliArguments.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Reflection;
 using VGAudio.Codecs.CriAdx;
 using VGAudio.Codecs.CriHca;
+using VGAudio.Utilities;
 
 namespace VGAudio.Cli
 {
@@ -327,6 +328,12 @@ namespace VGAudio.Cli
                         case "-LIMIT-BITRATE":
                             options.LimitBitrate = true;
                             continue;
+                        case "-BIG-ENDIAN":
+                            options.Endianness = Endianness.BigEndian;
+                            continue;
+                        case "-LITTLE-ENDIAN":
+                            options.Endianness = Endianness.LittleEndian;
+                            continue;
                     }
                 }
 
@@ -508,6 +515,10 @@ namespace VGAudio.Cli
             Console.WriteLine("  -o  <dir>        Specify the output directory");
             Console.WriteLine("  -r               Recurse subdirectories");
             Console.WriteLine("      --out-format The file type or container to save files as");
+
+            Console.WriteLine("\nBCSTM/BFSTM Options:");
+            Console.WriteLine("      --little-endian   Makes the output file little-endian");
+            Console.WriteLine("      --big-endian      Makes the output file big-endian");
 
             Console.WriteLine("\nADX Options:");
             Console.WriteLine("      --adxtype    The ADX encoding type to use");

--- a/src/VGAudio.Cli/CliArguments.cs
+++ b/src/VGAudio.Cli/CliArguments.cs
@@ -405,7 +405,8 @@ namespace VGAudio.Cli
 
             if (options.OutFiles.Count == 0)
             {
-                options.OutFiles.Add(new AudioFile { Path = Path.GetFileNameWithoutExtension(options.InFiles[0].Path) + ".dsp" });
+                string ext = options.InFiles[0].Type != FileType.Wave ? ".wav" : ".dsp";
+                options.OutFiles.Add(new AudioFile { Path = Path.GetFileNameWithoutExtension(options.InFiles[0].Path) + ext });
             }
 
             foreach (AudioFile file in options.OutFiles)

--- a/src/VGAudio.Cli/CreateConfiguration.cs
+++ b/src/VGAudio.Cli/CreateConfiguration.cs
@@ -76,6 +76,7 @@ namespace VGAudio.Cli
         public static Configuration Bxstm(Options options, Configuration inConfig = null)
         {
             var config = inConfig as BxstmConfiguration ?? new BxstmConfiguration();
+            config.Endianness = options.Endianness;
 
             switch (options.OutFormat)
             {

--- a/src/VGAudio.Cli/Options.cs
+++ b/src/VGAudio.Cli/Options.cs
@@ -2,6 +2,7 @@
 using VGAudio.Codecs.CriAdx;
 using VGAudio.Codecs.CriHca;
 using VGAudio.Formats;
+using VGAudio.Utilities;
 
 namespace VGAudio.Cli
 {
@@ -33,6 +34,7 @@ namespace VGAudio.Cli
         public CriAdxType AdxType { get; set; } // ADX
         public string KeyString { get; set; } //ADX
         public ulong KeyCode { get; set; } //ADX
+        public Endianness? Endianness { get; set; }
 
         public CriHcaQuality HcaQuality { get; set; }
         public int Bitrate { get; set; }


### PR DESCRIPTION
- If the input file is not a WAV file, the default output type will be WAV.
- If the input file is a WAV file, the default output type will be DSP.
- Allow setting the endianness in BCSTM and BFSTM files. (Fixes #74)