### PR TITLE
Improve support for Smash Ultimate

### DIFF
--- a/src/VGAudio.Cli/CliArguments.cs
+++ b/src/VGAudio.Cli/CliArguments.cs
@@ -361,6 +361,9 @@ namespace VGAudio.Cli
                             options.NxOpusHeaderType = nxHeaderType;
                             i++;
                             continue;
+                        case "-CBR":
+                            options.EncodeCbr = true;
+                            continue;
                     }
                 }
 
@@ -560,12 +563,14 @@ namespace VGAudio.Cli
 
             Console.WriteLine("\nHCA Options:");
             Console.WriteLine("      --hcaquality     The quality level to use for the HCA file");
-            Console.WriteLine("      --bitrate        The bitrate in bps of the output HCA file");
+            Console.WriteLine("      --bitrate        The bitrate in bits per second of the output HCA file");
             Console.WriteLine("                       --bitrate takes precedence over --hcaquality");
             Console.WriteLine("      --limit-bitrate  This flag sets a limit on how low the bitrate can go");
             Console.WriteLine("                       This limit depends on the properties of the input file");
 
             Console.WriteLine("\nSwitch Opus Options:");
+            Console.WriteLine("      --bitrate        The bitrate in bits per second of the output file");
+            Console.WriteLine("      --cbr            Encode the file using a constant bitrate");
             Console.WriteLine("      --opusheader     The type of header to use for the generated Opus file");
             Console.WriteLine("                       Available types: " + opusHeaderTypes);
         }

--- a/src/VGAudio.Cli/CreateConfiguration.cs
+++ b/src/VGAudio.Cli/CreateConfiguration.cs
@@ -154,6 +154,7 @@ namespace VGAudio.Cli
             NxOpusConfiguration config = inConfig as NxOpusConfiguration ?? new NxOpusConfiguration();
 
             config.HeaderType = options.NxOpusHeaderType;
+            config.EncodeCbr = options.EncodeCbr;
             if (options.Bitrate != 0) config.Bitrate = options.Bitrate;
             
             return config;

--- a/src/VGAudio.Cli/Options.cs
+++ b/src/VGAudio.Cli/Options.cs
@@ -42,6 +42,7 @@ namespace VGAudio.Cli
         public bool LimitBitrate { get; set; }
 
         public NxOpusHeaderType NxOpusHeaderType { get; set; } // Switch Opus
+        public bool EncodeCbr { get; set; }
     }
 
     internal class JobFiles

--- a/src/VGAudio/Codecs/Opus/OpusParameters.cs
+++ b/src/VGAudio/Codecs/Opus/OpusParameters.cs
@@ -5,5 +5,6 @@
         public OpusParameters() { }
         public OpusParameters(CodecParameters source) : base(source) { }
         public int Bitrate { get; set; }
+        public bool EncodeCbr { get; set; }
     }
 }

--- a/src/VGAudio/Containers/Opus/NxOpusConfiguration.cs
+++ b/src/VGAudio/Containers/Opus/NxOpusConfiguration.cs
@@ -4,5 +4,6 @@
     {
         public NxOpusHeaderType HeaderType { get; set; }
         public int Bitrate { get; set; }
+        public bool EncodeCbr { get; set; }
     }
 }

--- a/src/VGAudio/Containers/Opus/NxOpusWriter.cs
+++ b/src/VGAudio/Containers/Opus/NxOpusWriter.cs
@@ -72,10 +72,18 @@ namespace VGAudio.Containers.Opus
             writer.Write(0x18);
             writer.Write((byte)0);
             writer.Write((byte)Format.ChannelCount);
-            if (Format.Frames.Count != 0)
-                writer.Write((short)(Format.Frames[0].Length + 8));
-            else
-                writer.Write((short)0);
+            // If frame length is inconsistent, frameLength = 0
+            int frameLength = 0;
+            if (Format.Frames.Count > 0){
+                frameLength = Format.Frames[0].Length;
+                foreach(OpusFrame frame in Format.Frames){
+                    if(frame.Length != frameLength){
+                        frameLength = 0;
+                        break;
+                    }
+                }
+            }
+            writer.Write((short)(frameLength + 8));
             writer.Write(Format.SampleRate);
             writer.Write(0x20);
             writer.Write(0);

--- a/src/VGAudio/Containers/Opus/NxOpusWriter.cs
+++ b/src/VGAudio/Containers/Opus/NxOpusWriter.cs
@@ -72,7 +72,10 @@ namespace VGAudio.Containers.Opus
             writer.Write(0x18);
             writer.Write((byte)0);
             writer.Write((byte)Format.ChannelCount);
-            writer.Write((short)0);
+            if (Format.Frames.Count != 0)
+                writer.Write((short)(Format.Frames[0].Length + 8));
+            else
+                writer.Write((short)0);
             writer.Write(Format.SampleRate);
             writer.Write(0x20);
             writer.Write(0);
@@ -94,7 +97,7 @@ namespace VGAudio.Containers.Opus
             writer.Write(Format.SampleRate);
             writer.Write(Format.LoopStart);
             writer.Write(Format.LoopEnd);
-            writer.Write(0);
+            writer.Write(Format.Looping ? 0x10 : 0);
             writer.Write(NamcoHeaderSize);
             writer.Write(StandardFileSize);
 

--- a/src/VGAudio/Containers/Opus/NxOpusWriter.cs
+++ b/src/VGAudio/Containers/Opus/NxOpusWriter.cs
@@ -39,6 +39,7 @@ namespace VGAudio.Containers.Opus
             var encodingConfig = new OpusParameters
             {
                 Bitrate = Configuration.Bitrate,
+                EncodeCbr = Configuration.EncodeCbr,
                 Progress = Configuration.Progress
             };
 
@@ -74,10 +75,13 @@ namespace VGAudio.Containers.Opus
             writer.Write((byte)Format.ChannelCount);
             // If frame length is inconsistent, frameLength = 0
             int frameLength = 0;
-            if (Format.Frames.Count > 0){
+            if (Format.Frames.Count > 0)
+            {
                 frameLength = Format.Frames[0].Length;
-                foreach(OpusFrame frame in Format.Frames){
-                    if(frame.Length != frameLength){
+                foreach (OpusFrame frame in Format.Frames)
+                {
+                    if (frame.Length != frameLength)
+                    {
                         frameLength = 0;
                         break;
                     }

--- a/src/VGAudio/Formats/Opus/OpusFormat.cs
+++ b/src/VGAudio/Formats/Opus/OpusFormat.cs
@@ -92,7 +92,9 @@ namespace VGAudio.Formats.Opus
         public override OpusFormat EncodeFromPcm16(Pcm16Format pcm16, OpusParameters config)
         {
             const int frameSize = 960;
+
             var encoder = new OpusEncoder(pcm16.SampleRate, pcm16.ChannelCount, OpusApplication.OPUS_APPLICATION_AUDIO);
+            encoder.UseVBR = !config.EncodeCbr;
 
             if (config.Bitrate > 0) encoder.Bitrate = config.Bitrate;
 

--- a/src/VGAudio/Formats/Opus/OpusFormat.cs
+++ b/src/VGAudio/Formats/Opus/OpusFormat.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Concentus.Enums;
 using Concentus.Structs;
+using VGAudio.Codecs;
 using VGAudio.Codecs.Opus;
 using VGAudio.Formats.Pcm16;
 using VGAudio.Utilities;
@@ -26,16 +27,18 @@ namespace VGAudio.Formats.Opus
             HasFinalRange = b.HasFinalRangeSet;
         }
 
-        public override Pcm16Format ToPcm16()
+        public override Pcm16Format ToPcm16() => ToPcm16(null);
+        public override Pcm16Format ToPcm16(CodecParameters config) => ToPcm16(new OpusParameters(config));
+        public override Pcm16Format ToPcm16(OpusParameters config)
         {
-            short[][] audio = Decode();
+            short[][] audio = Decode(config);
 
             return new Pcm16FormatBuilder(audio, SampleRate)
                 .WithLoop(Looping, UnalignedLoopStart, UnalignedLoopEnd)
                 .Build();
         }
 
-        private short[][] Decode()
+        private short[][] Decode(OpusParameters config)
         {
             var dec = new OpusDecoder(SampleRate, ChannelCount);
 
@@ -45,6 +48,8 @@ namespace VGAudio.Formats.Opus
             var pcmBuffer = new short[ChannelCount * maxSampleCount];
             int outPos = 0;
             int remaining = SampleCount + PreSkipCount;
+
+            config.Progress?.SetTotal(Frames.Count);
 
             for (int i = 0; i < Frames.Count; i++)
             {
@@ -57,7 +62,11 @@ namespace VGAudio.Formats.Opus
 
                 outPos += frameSamples;
                 remaining -= frameSamples;
+
+                config.Progress?.ReportAdd(1);
             }
+
+            config.Progress?.SetTotal(0);
 
             return pcmOut;
         }
@@ -109,6 +118,8 @@ namespace VGAudio.Formats.Opus
 
             short[] encodeInput = pcmData;
 
+            config.Progress?.SetTotal(pcm16.SampleCount.DivideByRoundUp(frameSize));
+
             while (remaining >= 0)
             {
                 int encodeCount = Math.Min(frameSize, remaining);
@@ -136,11 +147,15 @@ namespace VGAudio.Formats.Opus
 
                 remaining -= encodeCount;
                 inPos += encodeCount * pcm16.ChannelCount;
+
+                config.Progress?.ReportAdd(1);
             }
 
             OpusFormat format = new OpusFormatBuilder(pcm16.SampleCount, pcm16.SampleRate, pcm16.ChannelCount, encoder.Lookahead, frames)
                 .WithLoop(pcm16.Looping, pcm16.LoopStart, pcm16.LoopEnd)
                 .Build();
+
+            config.Progress?.SetTotal(0);
 
             return format;
         }


### PR DESCRIPTION
Before, NxOpusWriter would not write either the frame length field (in the standard header) or the looping bitfield (in the namco header), causing issues with Smash Ultimate, which requires a consistent frame size (as well as a non-zero frame size in the header to accompany it).

My changes consist of:
* Writing the frame length in the header if and only if it is consistent, otherwise the same behavior as before is exhibited
* Writing the looping bit (the 5th least significant) in the bitfield within the NxOpus namco header

To complete support for Smash Ultimate the following change is needed:
* A means of composing equal-sized frames, presumably during encoding(?) in order for these changes to matter