### PR TITLE
Support for Skyrim NX Audio formats

### DIFF
--- a/src/VGAudio.Cli/AudioFormat.cs
+++ b/src/VGAudio.Cli/AudioFormat.cs
@@ -6,6 +6,7 @@
         Pcm16,
         Pcm8,
         GcAdpcm,
+        McAdpcm,
         ImaAdpcm,
         CriAdx,
         CriAdxFixed,

--- a/src/VGAudio.Cli/CliArguments.cs
+++ b/src/VGAudio.Cli/CliArguments.cs
@@ -367,9 +367,6 @@ namespace VGAudio.Cli
                         case "-CBR":
                             options.EncodeCbr = true;
                             continue;
-                        case "-FUZ":
-                            options.SkyrimFuz = true;
-                            continue;
                     }
                 }
 
@@ -577,7 +574,6 @@ namespace VGAudio.Cli
             Console.WriteLine("\nSwitch Opus Options:");
             Console.WriteLine("      --bitrate        The bitrate in bits per second of the output file");
             Console.WriteLine("      --cbr            Encode the file using a constant bitrate");
-            Console.WriteLine("      --fuz            Save the file as a Skyrim NX FUZ container (with corresponding LIP)");
             Console.WriteLine("      --opusheader     The type of header to use for the generated Opus file");
             Console.WriteLine("                       Available types: " + opusHeaderTypes);
         }

--- a/src/VGAudio.Cli/CliArguments.cs
+++ b/src/VGAudio.Cli/CliArguments.cs
@@ -353,6 +353,9 @@ namespace VGAudio.Cli
                                 case "NAMCO":
                                     nxHeaderType = NxOpusHeaderType.Namco;
                                     break;
+                                case "SKYRIM":
+                                    nxHeaderType = NxOpusHeaderType.Skyrim;
+                                    break;
                                 default:
                                     Console.WriteLine("Invalid header type");
                                     return null;
@@ -571,6 +574,7 @@ namespace VGAudio.Cli
             Console.WriteLine("\nSwitch Opus Options:");
             Console.WriteLine("      --bitrate        The bitrate in bits per second of the output file");
             Console.WriteLine("      --cbr            Encode the file using a constant bitrate");
+            Console.WriteLine("      --fuz            Save the file as a Skyrim NX FUZ container (with corresponding LIP)");
             Console.WriteLine("      --opusheader     The type of header to use for the generated Opus file");
             Console.WriteLine("                       Available types: " + opusHeaderTypes);
         }

--- a/src/VGAudio.Cli/CliArguments.cs
+++ b/src/VGAudio.Cli/CliArguments.cs
@@ -367,6 +367,9 @@ namespace VGAudio.Cli
                         case "-CBR":
                             options.EncodeCbr = true;
                             continue;
+                        case "-FUZ":
+                            options.SkyrimFuz = true;
+                            continue;
                     }
                 }
 

--- a/src/VGAudio.Cli/ContainerTypes.cs
+++ b/src/VGAudio.Cli/ContainerTypes.cs
@@ -37,7 +37,7 @@ namespace VGAudio.Cli
             [FileType.Hca] = new ContainerType(new[] { "hca" }, () => new HcaReader(), () => new HcaWriter(), CreateConfiguration.Hca),
             [FileType.Genh] = new ContainerType(new[] { "genh" }, () => new GenhReader(), null, null),
             [FileType.Atrac9] = new ContainerType(new[] { "at9" }, () => new At9Reader(), null, null),
-            [FileType.NxOpus] = new ContainerType(new[] { "lopus", "nop" }, () => new NxOpusReader(), () => new NxOpusWriter(), CreateConfiguration.NxOpus),
+            [FileType.NxOpus] = new ContainerType(new[] { "lopus", "nop", "fuz" }, () => new NxOpusReader(), () => new NxOpusWriter(), CreateConfiguration.NxOpus),
             [FileType.OggOpus] = new ContainerType(new[] { "opus" }, () => new OggOpusReader(), () => new OggOpusWriter(), CreateConfiguration.NxOpus)
         };
 

--- a/src/VGAudio.Cli/ContainerTypes.cs
+++ b/src/VGAudio.Cli/ContainerTypes.cs
@@ -12,6 +12,7 @@ using VGAudio.Containers.Idsp;
 using VGAudio.Containers.NintendoWare;
 using VGAudio.Containers.Opus;
 using VGAudio.Containers.Wave;
+using VGAudio.Containers.McAdpcm;
 
 namespace VGAudio.Cli
 {
@@ -21,6 +22,7 @@ namespace VGAudio.Cli
         {
             [FileType.Wave] = new ContainerType(new[] { "wav", "wave", "lwav" }, () => new WaveReader(), () => new WaveWriter(), CreateConfiguration.Wave),
             [FileType.Dsp] = new ContainerType(new[] { "dsp", "mdsp" }, () => new DspReader(), () => new DspWriter(), CreateConfiguration.Dsp),
+            [FileType.McAdpcm] = new ContainerType(new[] { "mcadpcm" }, () => new McAdpcmReader(), () => new McAdpcmWriter(), CreateConfiguration.McAdpcm),
             [FileType.Idsp] = new ContainerType(new[] { "idsp" }, () => new IdspReader(), () => new IdspWriter(), CreateConfiguration.Idsp),
             [FileType.Brstm] = new ContainerType(new[] { "brstm" }, () => new BrstmReader(), () => new BrstmWriter(), CreateConfiguration.Bxstm),
             [FileType.Bcstm] = new ContainerType(new[] { "bcstm" }, () => new BCFstmReader(), () => new BCFstmWriter(NwTarget.Ctr), CreateConfiguration.Bxstm),

--- a/src/VGAudio.Cli/CreateConfiguration.cs
+++ b/src/VGAudio.Cli/CreateConfiguration.cs
@@ -4,6 +4,7 @@ using VGAudio.Codecs.CriHca;
 using VGAudio.Containers;
 using VGAudio.Containers.Adx;
 using VGAudio.Containers.Dsp;
+using VGAudio.Containers.McAdpcm;
 using VGAudio.Containers.Hca;
 using VGAudio.Containers.Hps;
 using VGAudio.Containers.Idsp;
@@ -37,6 +38,26 @@ namespace VGAudio.Cli
         public static Configuration Dsp(Options options, Configuration inConfig = null)
         {
             DspConfiguration config = inConfig as DspConfiguration ?? new DspConfiguration();
+
+            switch (options.OutFormat)
+            {
+                case AudioFormat.Pcm16:
+                    throw new InvalidDataException("Can't use format PCM16 with DSP files");
+                case AudioFormat.Pcm8:
+                    throw new InvalidDataException("Can't use format PCM8 with DSP files");
+            }
+
+            if (options.LoopAlignment > 0)
+            {
+                config.LoopPointAlignment = options.LoopAlignment;
+            }
+
+            return config;
+        }
+
+        public static Configuration McAdpcm(Options options, Configuration inConfig = null)
+        {
+            McAdpcmConfiguration config = inConfig as McAdpcmConfiguration ?? new McAdpcmConfiguration();
 
             switch (options.OutFormat)
             {

--- a/src/VGAudio.Cli/Metadata/Containers/McAdpcm.cs
+++ b/src/VGAudio.Cli/Metadata/Containers/McAdpcm.cs
@@ -1,0 +1,41 @@
+﻿using System.IO;
+using System.Text;
+using VGAudio.Containers.McAdpcm;
+
+namespace VGAudio.Cli.Metadata.Containers
+{
+    internal class McAdpcm : MetadataReader
+    {
+        public override Common ToCommon(object structure)
+        {
+            if (!(structure is McAdpcmStructure McAdpcm)) throw new InvalidDataException("Could not parse file metadata.");
+
+            return new Common
+            {
+                SampleCount = McAdpcm.SampleCount,
+                SampleRate = McAdpcm.SampleRate,
+                ChannelCount = McAdpcm.ChannelCount,
+                Format = AudioFormat.McAdpcm,
+                Looping = McAdpcm.Looping,
+                LoopStart = McAdpcm.LoopStart,
+                LoopEnd = McAdpcm.LoopEnd
+            };
+        }
+
+        public override object ReadMetadata(Stream stream) => new McAdpcmReader().ReadMetadata(stream);
+
+        public override void PrintSpecificMetadata(object structure, StringBuilder builder)
+        {
+            if (!(structure is McAdpcmStructure McAdpcm)) throw new InvalidDataException("Could not parse file metadata.");
+
+            builder.AppendLine();
+
+            builder.AppendLine($"Nibble Count: {McAdpcm.NibbleCount}");
+            builder.AppendLine($"Start Address: 0x{McAdpcm.StartAddress:X8}");
+            builder.AppendLine($"End Address: 0x{McAdpcm.EndAddress:X8}");
+            builder.AppendLine($"Current Address: 0x{McAdpcm.CurrentAddress:X8}");
+
+            GcAdpcm.PrintAdpcmMetadata(McAdpcm.Channels, builder);
+        }
+    }
+}

--- a/src/VGAudio.Cli/Metadata/Print.cs
+++ b/src/VGAudio.Cli/Metadata/Print.cs
@@ -50,6 +50,7 @@ namespace VGAudio.Cli.Metadata
             [AudioFormat.Pcm16] = "16-bit PCM",
             [AudioFormat.Pcm8] = "8-bit PCM",
             [AudioFormat.GcAdpcm] = "GameCube \"DSP\" 4-bit ADPCM",
+            [AudioFormat.McAdpcm] = "Nintendo Switch Multi-Channel \"DSP\" 4-bit ADPCM",
             [AudioFormat.ImaAdpcm] = "IMA 4-bit ADPCM",
             [AudioFormat.CriAdx] = "CRI ADX 4-bit ADPCM",
             [AudioFormat.CriAdxFixed] = "CRI ADX 4-bit ADPCM with fixed coefficients",
@@ -62,6 +63,7 @@ namespace VGAudio.Cli.Metadata
         {
             [FileType.Wave] = new Wave(),
             [FileType.Dsp] = new Dsp(),
+            [FileType.McAdpcm] = new McAdpcm(),
             [FileType.Idsp] = new Idsp(),
             [FileType.Brstm] = new Brstm(),
             [FileType.Bcstm] = new Bcstm(),

--- a/src/VGAudio.Cli/Options.cs
+++ b/src/VGAudio.Cli/Options.cs
@@ -43,8 +43,6 @@ namespace VGAudio.Cli
 
         public NxOpusHeaderType NxOpusHeaderType { get; set; } // Switch Opus
         public bool EncodeCbr { get; set; }
-
-        public bool SkyrimFuz { get; set; }
     }
 
     internal class JobFiles
@@ -96,6 +94,7 @@ namespace VGAudio.Cli
         Atrac9,
         NxOpus,
         OggOpus,
-        McAdpcm
+        McAdpcm,
+        Fuz
     }
 }

--- a/src/VGAudio.Cli/Options.cs
+++ b/src/VGAudio.Cli/Options.cs
@@ -93,6 +93,7 @@ namespace VGAudio.Cli
         Genh,
         Atrac9,
         NxOpus,
-        OggOpus
+        OggOpus,
+        McAdpcm
     }
 }

--- a/src/VGAudio.Cli/Options.cs
+++ b/src/VGAudio.Cli/Options.cs
@@ -43,6 +43,8 @@ namespace VGAudio.Cli
 
         public NxOpusHeaderType NxOpusHeaderType { get; set; } // Switch Opus
         public bool EncodeCbr { get; set; }
+
+        public bool SkyrimFuz { get; set; }
     }
 
     internal class JobFiles

--- a/src/VGAudio/Containers/McAdpcm/McAdpcmConfiguration.cs
+++ b/src/VGAudio/Containers/McAdpcm/McAdpcmConfiguration.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using static VGAudio.Codecs.GcAdpcm.GcAdpcmMath;
+
+namespace VGAudio.Containers.McAdpcm
+{
+    /// <summary>
+    /// Contains the options used to build the McAdpcm file.
+    /// </summary>
+    public class McAdpcmConfiguration : Configuration
+    {
+        private int _samplesPerInterleave = 0x3800;
+        /// <summary>
+        /// If <c>true</c>, recalculates the loop context when building the McAdpcm.
+        /// If <c>false</c>, reuses the loop context read from an imported McAdpcm
+        /// if available.
+        /// Default is <c>true</c>.
+        /// </summary>
+        public bool RecalculateLoopContext { get; set; } = true;
+
+        /// <summary>
+        /// The number of samples in each block when interleaving
+        /// the audio data in the audio file.
+        /// Must be divisible by 14.
+        /// Default is 14,336 (0x3800).
+        /// </summary>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if value is negative 
+        /// or not divisible by 14.</exception>
+        public int SamplesPerInterleave
+        {
+            get => _samplesPerInterleave;
+            set
+            {
+                if (value < 1)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), value,
+                        "Number of samples per interleave must be positive");
+                }
+                if (value % SamplesPerFrame != 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), value,
+                        "Number of samples per interleave must be divisible by 14");
+                }
+                _samplesPerInterleave = value;
+            }
+        }
+
+        /// <summary>
+        /// When building the McAdpcm file, the loop points and audio will
+        /// be adjusted so that the start loop point is a multiple of
+        /// this number. Default is 1.
+        /// </summary>
+        public int LoopPointAlignment { get; set; } = 1;
+    }
+}

--- a/src/VGAudio/Containers/McAdpcm/McAdpcmReader.cs
+++ b/src/VGAudio/Containers/McAdpcm/McAdpcmReader.cs
@@ -1,0 +1,132 @@
+﻿using System.IO;
+using System.Linq;
+using VGAudio.Formats;
+using VGAudio.Formats.GcAdpcm;
+using VGAudio.Utilities;
+using static VGAudio.Codecs.GcAdpcm.GcAdpcmMath;
+using static VGAudio.Utilities.Helpers;
+
+namespace VGAudio.Containers.McAdpcm
+{
+    public class McAdpcmReader : AudioReader<McAdpcmReader, McAdpcmStructure, McAdpcmConfiguration>
+    {
+        private static int DspHeaderCoefOffset = 0x1C;
+        private static int DspHeaderSize => 0x60;
+
+        protected override McAdpcmStructure ReadFile(Stream stream, bool readAudioData = true)
+        {
+            var structure = new McAdpcmStructure();
+
+            ReadHeader(GetBinaryReader(stream, Endianness.LittleEndian), structure);
+
+            if (readAudioData) {
+                using (BinaryReader reader = GetBinaryReader(stream, Endianness.BigEndian))
+                {
+                    reader.BaseStream.Position = structure.McadpcmHeaderSize;
+                    ReadData(reader, structure);
+                }
+            }
+
+            return structure;
+        }
+
+        protected override IAudioFormat ToAudioStream(McAdpcmStructure structure)
+        {
+            var channels = new GcAdpcmChannel[structure.ChannelCount];
+
+            for (int c = 0; c < structure.ChannelCount; c++)
+            {
+                var channelBuilder = new GcAdpcmChannelBuilder(structure.AudioData[c], structure.Channels[c].Coefs, structure.SampleCount)
+                {
+                    Gain = structure.Channels[c].Gain,
+                    StartContext = structure.Channels[c].Start
+                };
+
+                channelBuilder
+                    .WithLoop(structure.Looping, structure.LoopStart, structure.LoopEnd)
+                    .WithLoopContext(structure.LoopStart, structure.Channels[c].Loop.PredScale,
+                        structure.Channels[c].Loop.Hist1, structure.Channels[c].Loop.Hist2);
+
+                channels[c] = channelBuilder.Build();
+            }
+
+            return new GcAdpcmFormatBuilder(channels, structure.SampleRate)
+                .WithLoop(structure.Looping, structure.LoopStart, structure.LoopEnd)
+                .Build();
+        }
+
+        private static void ReadHeader(BinaryReader reader, McAdpcmStructure structure)
+        {
+            structure.ChannelCount = reader.ReadInt32();
+
+            if (structure.ChannelCount > 2)
+            {
+                throw new InvalidDataException($"McAdpcm cannot have more than 2 channels.");
+            }
+
+            structure.McadpcmHeaderSize = reader.ReadInt32();
+            structure.DspChannelDataSize = reader.ReadInt32(); // channel 0 data size
+
+            // A Stereo MCADPCM has 2 additional 32 bit fields  we don't need for computation
+            // - channel1 data offset from file start
+            // - channel1 data size (never found a case where <> than Channel0 data size)
+            reader.BaseStream.Position += (structure.ChannelCount - 1) * 0x02 * sizeof(int);
+
+            structure.SampleCount = reader.ReadInt32();
+            structure.NibbleCount = reader.ReadInt32();
+            structure.SampleRate = reader.ReadInt32();
+            structure.Looping = reader.ReadInt16() == 1;
+            structure.Format = reader.ReadInt16();
+            structure.StartAddress = reader.ReadInt32();
+            structure.EndAddress = reader.ReadInt32();
+            structure.CurrentAddress = reader.ReadInt32();
+
+            structure.Channels.Add(new GcAdpcmChannelInfo
+            {
+                Coefs = Enumerable.Range(0, 16).Select(x => reader.ReadInt16()).ToArray(),
+                Gain = reader.ReadInt16(),
+                Start = new GcAdpcmContext(reader),
+                Loop = new GcAdpcmContext(reader)
+            });
+
+            if (structure.ChannelCount == 2)
+            {
+                reader.BaseStream.Position = structure.McadpcmHeaderSize + structure.DspChannelDataSize + DspHeaderCoefOffset;
+
+                structure.Channels.Add(new GcAdpcmChannelInfo
+                {
+                    Coefs = Enumerable.Range(0, 16).Select(x => reader.ReadInt16()).ToArray(),
+                    Gain = reader.ReadInt16(),
+                    Start = new GcAdpcmContext(reader),
+                    Loop = new GcAdpcmContext(reader)
+                });
+            }
+
+            if (reader.BaseStream.Length < structure.McadpcmHeaderSize + structure.DspChannelDataSize * structure.ChannelCount)
+            {
+                throw new InvalidDataException($"File doesn't contain enough data for {structure.SampleCount} samples");
+            }
+
+            if (SampleCountToNibbleCount(structure.SampleCount) != structure.NibbleCount)
+            {
+                throw new InvalidDataException("Sample count and nibble count do not match");
+            }
+
+            if (structure.Format != 0)
+            {
+                throw new InvalidDataException($"File does not contain ADPCM audio. Specified format is {structure.Format}");
+            }
+        }
+
+        private static void ReadData(BinaryReader reader, McAdpcmStructure structure)
+        {
+            structure.AudioData = new byte[structure.ChannelCount][];
+
+            for (int i = 0; i < structure.ChannelCount; i++)
+            {
+                reader.BaseStream.Position = structure.McadpcmHeaderSize + DspHeaderSize + (structure.DspChannelDataSize) * i;
+                structure.AudioData[i] = reader.ReadBytes(structure.DspChannelDataSize - DspHeaderSize);
+            }
+        }
+    }
+}

--- a/src/VGAudio/Containers/McAdpcm/McAdpcmStructure.cs
+++ b/src/VGAudio/Containers/McAdpcm/McAdpcmStructure.cs
@@ -1,0 +1,85 @@
+﻿using System.Collections.Generic;
+using VGAudio.Codecs.GcAdpcm;
+using VGAudio.Formats.GcAdpcm;
+
+namespace VGAudio.Containers.McAdpcm
+{
+    /// <summary>
+    /// Defines the structure of a McAdpcm file.
+    /// </summary>
+    public class McAdpcmStructure
+    {
+        internal McAdpcmStructure() { }
+
+        /// <summary>
+        /// The McAdpcm header size can be 0x0C 0r 0X14 large.
+        /// </summary>
+        public int McadpcmHeaderSize { get; set; }
+
+        /// <summary>
+        /// The McAdpcm DspAdpcm channel data size.
+        /// </summary>
+        public int DspChannelDataSize { get; set; }
+
+        /// <summary>
+        /// The number of samples in the McAdpcm.
+        /// </summary>
+        public int SampleCount { get; set; }
+        /// <summary>
+        /// The number of ADPCM nibbles in the McAdpcm.
+        /// </summary>
+        public int NibbleCount { get; set; }
+        /// <summary>
+        /// The sample rate of the audio.
+        /// </summary>
+        public int SampleRate { get; set; }
+        /// <summary>
+        /// This flag is set if the McAdpcm loops.
+        /// </summary>
+        public bool Looping { get; set; }
+        /// <summary>
+        /// The format of
+        /// </summary>
+        public short Format { get; set; }
+        /// <summary>
+        /// The address, in nibbles, of the start
+        /// loop point.
+        /// </summary>
+        public int StartAddress { get; set; }
+        /// <summary>
+        /// The address, in nibbles, of the end
+        /// loop point.
+        /// </summary>
+        public int EndAddress { get; set; }
+        /// <summary>
+        /// The address, in nibbles, of the initial
+        /// playback position.
+        /// </summary>
+        public int CurrentAddress { get; set; }
+        /// <summary>
+        /// The number of channels in the McAdpcm file.
+        /// Only used in multi-channel McAdpcm files.
+        /// </summary>
+        public int ChannelCount { get; set; }
+        /// <summary>
+        /// The number of ADPCM frames in each
+        /// interleaved audio data block.
+        /// Only used in multi-channel McAdpcm files.
+        /// </summary>
+        public int FramesPerInterleave { get; set; }
+        /// <summary>
+        /// The ADPCM information for each channel.
+        /// </summary>
+        public IList<GcAdpcmChannelInfo> Channels { get; } = new List<GcAdpcmChannelInfo>();
+
+        /// <summary>
+        /// The start loop point in samples.
+        /// </summary>
+        public int LoopStart => GcAdpcmMath.NibbleToSample(StartAddress);
+        /// <summary>
+        /// The end loop point in samples.
+        /// </summary>
+        public int LoopEnd => GcAdpcmMath.NibbleToSample(EndAddress);
+        internal byte[][] AudioData { get; set; }
+    }
+}

--- a/src/VGAudio/Containers/McAdpcm/McAdpcmWriter.cs
+++ b/src/VGAudio/Containers/McAdpcm/McAdpcmWriter.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using VGAudio.Codecs.GcAdpcm;
+using VGAudio.Formats;
+using VGAudio.Formats.GcAdpcm;
+using VGAudio.Utilities;
+using static VGAudio.Codecs.GcAdpcm.GcAdpcmMath;
+using static VGAudio.Utilities.Helpers;
+
+namespace VGAudio.Containers.McAdpcm
+{
+    public class McAdpcmWriter : AudioWriter<McAdpcmWriter, McAdpcmConfiguration>
+    {
+        private static int DspHeaderSize => 0x60;
+
+        private GcAdpcmFormat Adpcm { get; set; }
+
+        protected override int FileSize => (ChannelCount == 1 ? 0x0C : 0x014) + (DspHeaderSize + AudioDataSize) * ChannelCount;
+
+        private int ChannelCount => Adpcm.ChannelCount;
+
+        private int McAdpcmHeaderSize => (ChannelCount == 1 ? 0x0C : 0x14);
+
+        private int SampleCount => (Configuration.TrimFile && Adpcm.Looping ? LoopEnd : Math.Max(Adpcm.SampleCount, LoopEnd));
+        private short Format { get; } = 0; /* 0 for ADPCM */
+
+        private int SamplesPerInterleave => Configuration.SamplesPerInterleave;
+        private int BytesPerInterleave => SampleCountToByteCount(SamplesPerInterleave);
+        private int FramesPerInterleave => BytesPerInterleave / BytesPerFrame;
+
+        private int AlignmentSamples => GetNextMultiple(Adpcm.LoopStart, Configuration.LoopPointAlignment) - Adpcm.LoopStart;
+        private int LoopStart => Adpcm.LoopStart + AlignmentSamples;
+        private int LoopEnd => Adpcm.LoopEnd + AlignmentSamples;
+
+        private int StartAddr => SampleToNibble(Adpcm.Looping ? LoopStart : 0);
+        private int EndAddr => SampleToNibble(Adpcm.Looping ? LoopEnd : SampleCount - 1);
+        private static int CurAddr => SampleToNibble(0);
+
+        protected override void SetupWriter(AudioData audio)
+        {
+            Adpcm = audio.GetFormat<GcAdpcmFormat>(new GcAdpcmParameters { Progress = Configuration.Progress });
+        }
+
+        protected override void WriteStream(Stream stream)
+        {
+            WriteMcAdpcmHeader(GetBinaryWriter(stream, Endianness.LittleEndian));
+            for (int i = 0; i < ChannelCount; i++)
+            {
+                WriteDspMcAdpcmHeader(GetBinaryWriter(stream, Endianness.LittleEndian), i);
+                WriteData(GetBinaryWriter(stream, Endianness.BigEndian), i);
+            }
+        }
+
+        private void WriteMcAdpcmHeader(BinaryWriter writer)
+        {
+            writer.BaseStream.Position = 0;
+
+            writer.Write(ChannelCount); // channel count
+            writer.Write(McAdpcmHeaderSize); // header size
+            writer.Write(DspHeaderSize + AudioDataSize); // channel 0 data size
+            if (ChannelCount == 2)
+            {
+                writer.Write(McAdpcmHeaderSize + DspHeaderSize + AudioDataSize); // chabnel 1 offset
+                writer.Write(DspHeaderSize + AudioDataSize); // channel 1 data size
+            }
+        }
+
+        private void WriteDspMcAdpcmHeader(BinaryWriter writer, int i)
+        {
+            writer.BaseStream.Position = McAdpcmHeaderSize + (DspHeaderSize + AudioDataSize) * i;
+
+            GcAdpcmChannel channel = Adpcm.Channels[i];
+            writer.Write(SampleCount);
+            writer.Write(SampleCountToNibbleCount(SampleCount));
+            writer.Write(Adpcm.SampleRate);
+            writer.Write((short)(Adpcm.Looping ? 1 : 0));
+            writer.Write(Format);
+            writer.Write(StartAddr);
+            writer.Write(EndAddr);
+            writer.Write(CurAddr);
+            writer.Write(channel.Coefs.ToByteArray());
+            writer.Write(channel.Gain);
+            channel.StartContext.Write(writer);
+            if (!Adpcm.Looping)
+            {
+                channel.LoopContext.Write(writer);
+            }
+            else
+            {
+                writer.Write(new byte[3 * sizeof(short)]);
+            }
+            writer.Write((short)(0));
+            writer.Write((short)(0));
+        }
+
+        private void WriteData(BinaryWriter writer, int i)
+        {
+            writer.BaseStream.Position = McAdpcmHeaderSize + DspHeaderSize * (i+1) + AudioDataSize * i;
+            writer.Write(Adpcm.Channels[i].GetAdpcmAudio(), 0, SampleCountToByteCount(SampleCount));
+        }
+
+        /// <summary>
+        /// Size of a single channel's ADPCM audio data with padding when written to a file
+        /// </summary>
+        private int AudioDataSize => SampleCountToByteCount(SampleCount);
+    }
+}

--- a/src/VGAudio/Containers/Opus/NxOpusReader.cs
+++ b/src/VGAudio/Containers/Opus/NxOpusReader.cs
@@ -35,6 +35,12 @@ namespace VGAudio.Containers.Opus
                     stream.Position = startPos + structure.SadfDataOffset;
                     ReadStandardHeader(GetBinaryReader(stream, Endianness.LittleEndian), structure);
                     break;
+                case NxOpusHeaderType.Skyrim:
+                    ReadSkyrimHeader(GetBinaryReader(stream, Endianness.LittleEndian), structure);
+
+                    stream.Position = startPos + structure.SkyrimHeaderSize;
+                    ReadStandardHeader(GetBinaryReader(stream, Endianness.LittleEndian), structure);
+                    break;
             }
 
             BinaryReader reader = GetBinaryReader(stream, Endianness.BigEndian);
@@ -70,6 +76,7 @@ namespace VGAudio.Containers.Opus
                 case 0x80000001: return NxOpusHeaderType.Standard;
                 case 0x5355504F: return NxOpusHeaderType.Namco; // OPUS
                 case 0x66646173: return NxOpusHeaderType.Sadf; // sadf
+                case 0xFFD58D0A: return NxOpusHeaderType.Skyrim;
                 default: throw new NotImplementedException("This Opus header is not supported");
             }
         }
@@ -93,6 +100,15 @@ namespace VGAudio.Containers.Opus
 
             structure.DataType = reader.ReadUInt32();
             structure.DataSize = reader.ReadInt32();
+        }
+
+        private static void ReadSkyrimHeader(BinaryReader reader, NxOpusStructure structure)
+        {
+            if (reader.ReadUInt32() != 0xFFD58D0A) throw new InvalidDataException();
+            structure.SkyrimSoundDurationMS = reader.ReadInt32();
+            structure.ChannelCount = reader.ReadInt32();
+            structure.SkyrimHeaderSize = reader.ReadInt32(); ; // Skyrim NX OPUS Header Size == 0x14
+            structure.SkyrimOpusDataSize = reader.ReadInt32();
         }
 
         private static void ReadNamcoHeader(BinaryReader reader, NxOpusStructure structure)
@@ -165,6 +181,7 @@ namespace VGAudio.Containers.Opus
     {
         Standard,
         Namco,
-        Sadf
+        Sadf,
+        Skyrim
     }
 }

--- a/src/VGAudio/Containers/Opus/NxOpusStructure.cs
+++ b/src/VGAudio/Containers/Opus/NxOpusStructure.cs
@@ -30,6 +30,10 @@ namespace VGAudio.Containers.Opus
         public int NamcoCoreDataLength { get; set; }
         public int SadfDataOffset { get; set; }
 
+        public int SkyrimSoundDurationMS { get; set; }
+        public int SkyrimHeaderSize { get; set; }
+        public int SkyrimOpusDataSize { get; set; }
+
         public List<OpusFrame> Frames { get; set; } = new List<OpusFrame>();
     }
 }


### PR DESCRIPTION
Adds support for Skyrim NX audio formats:

- MCADPCM: As in Multi-Channel ADPCM. It contains a 3 or 5 UINT32 header followed by a sequence of DSP Header (liitle-endian), DSP Data (big-endian);

- OPUS: Skyrim has a special 5 UINT32 header on OPUS;

Full support for reading / writing / metadata MCADPCM inputs.