### PR TITLE
Skyrim NX sound support - MCADPCM and FUZ with OPUS

### DIFF
--- a/src/VGAudio.Cli/AudioFormat.cs
+++ b/src/VGAudio.Cli/AudioFormat.cs
@@ -6,6 +6,7 @@
         Pcm16,
         Pcm8,
         GcAdpcm,
+        McAdpcm,
         ImaAdpcm,
         CriAdx,
         CriAdxFixed,

--- a/src/VGAudio.Cli/CliArguments.cs
+++ b/src/VGAudio.Cli/CliArguments.cs
@@ -353,6 +353,9 @@ namespace VGAudio.Cli
                                 case "NAMCO":
                                     nxHeaderType = NxOpusHeaderType.Namco;
                                     break;
+                                case "SKYRIM":
+                                    nxHeaderType = NxOpusHeaderType.Skyrim;
+                                    break;
                                 default:
                                     Console.WriteLine("Invalid header type");
                                     return null;

--- a/src/VGAudio.Cli/ContainerTypes.cs
+++ b/src/VGAudio.Cli/ContainerTypes.cs
@@ -12,6 +12,7 @@ using VGAudio.Containers.Idsp;
 using VGAudio.Containers.NintendoWare;
 using VGAudio.Containers.Opus;
 using VGAudio.Containers.Wave;
+using VGAudio.Containers.McAdpcm;
 
 namespace VGAudio.Cli
 {
@@ -21,6 +22,7 @@ namespace VGAudio.Cli
         {
             [FileType.Wave] = new ContainerType(new[] { "wav", "wave", "lwav" }, () => new WaveReader(), () => new WaveWriter(), CreateConfiguration.Wave),
             [FileType.Dsp] = new ContainerType(new[] { "dsp", "mdsp" }, () => new DspReader(), () => new DspWriter(), CreateConfiguration.Dsp),
+            [FileType.McAdpcm] = new ContainerType(new[] { "mcadpcm" }, () => new McAdpcmReader(), () => new McAdpcmWriter(), CreateConfiguration.McAdpcm),
             [FileType.Idsp] = new ContainerType(new[] { "idsp" }, () => new IdspReader(), () => new IdspWriter(), CreateConfiguration.Idsp),
             [FileType.Brstm] = new ContainerType(new[] { "brstm" }, () => new BrstmReader(), () => new BrstmWriter(), CreateConfiguration.Bxstm),
             [FileType.Bcstm] = new ContainerType(new[] { "bcstm" }, () => new BCFstmReader(), () => new BCFstmWriter(NwTarget.Ctr), CreateConfiguration.Bxstm),
@@ -35,7 +37,7 @@ namespace VGAudio.Cli
             [FileType.Hca] = new ContainerType(new[] { "hca" }, () => new HcaReader(), () => new HcaWriter(), CreateConfiguration.Hca),
             [FileType.Genh] = new ContainerType(new[] { "genh" }, () => new GenhReader(), null, null),
             [FileType.Atrac9] = new ContainerType(new[] { "at9" }, () => new At9Reader(), null, null),
-            [FileType.NxOpus] = new ContainerType(new[] { "lopus", "nop" }, () => new NxOpusReader(), () => new NxOpusWriter(), CreateConfiguration.NxOpus),
+            [FileType.NxOpus] = new ContainerType(new[] { "lopus", "nop", "fuz" }, () => new NxOpusReader(), () => new NxOpusWriter(), CreateConfiguration.NxOpus),
             [FileType.OggOpus] = new ContainerType(new[] { "opus" }, () => new OggOpusReader(), () => new OggOpusWriter(), CreateConfiguration.NxOpus)
         };
 

--- a/src/VGAudio.Cli/Convert.cs
+++ b/src/VGAudio.Cli/Convert.cs
@@ -29,7 +29,7 @@ namespace VGAudio.Cli
 
             converter.EncodeFiles(files, options);
             converter.SetConfiguration(files.OutFiles[0].Type, options);
-            converter.WriteFile(files.OutFiles[0].Path);
+            converter.WriteFile(files.OutFiles[0].Path, options);
 
             return true;
         }
@@ -51,7 +51,7 @@ namespace VGAudio.Cli
             }
         }
 
-        private void WriteFile(string fileName)
+        private void WriteFile(string fileName, Options options)
         {
             string directory = Path.GetDirectoryName(fileName);
             if (!String.IsNullOrWhiteSpace(directory))
@@ -59,11 +59,62 @@ namespace VGAudio.Cli
                 Directory.CreateDirectory(directory);
             }
 
+            // check if a special FUZ header is required
+            bool isFuz = options.NxOpusHeaderType == Containers.Opus.NxOpusHeaderType.Skyrim && Path.GetExtension(fileName).ToLower() == "fuz";
+
             using (var stream = new FileStream(fileName, FileMode.Create, FileAccess.ReadWrite))
+            using (var writer = new BinaryWriter(stream, System.Text.Encoding.UTF8, true))
             using (var progress = new ProgressBar())
             {
                 if (ShowProgress) Configuration.Progress = progress;
+
+                // Add Skyrim FUZ header if output is an OPUS file with a Skyrim Header and a FUZ extension
+                if (isFuz)
+                {
+                    WriteFuzHeader(fileName, writer);
+                }
+
+                // Write audio data
                 OutType.GetWriter().WriteToStream(Audio, stream, Configuration);
+
+                // Need to pad the a FUZ file to the closest WORD boundary
+                if (isFuz)
+                {
+                    long fileSize = stream.Position;
+                    int fuzPadding = (int) (fileSize % 4);
+                    if (fuzPadding != 0) fuzPadding = 4 - fuzPadding;
+                    while (fuzPadding-- > 0) writer.Write(0x00);
+                }
+            }
+        }
+
+        private void WriteFuzHeader(string fileName, BinaryWriter writer)
+        {
+            const int fuzHeaderSize = 0x10;
+
+            string fileNameWithoutExtension = Path.GetDirectoryName(fileName) + Path.GetFileNameWithoutExtension(fileName);
+            string lipFileName = fileNameWithoutExtension + ".lip";
+
+            int lipSize = 0;
+            int lipPadding = 0;
+            byte[] lipData = { };
+
+            if (File.Exists(lipFileName))
+            {
+                lipData = File.ReadAllBytes(lipFileName);
+                lipSize = lipData.Length;
+                lipPadding = lipSize % 4;
+                if (lipPadding != 0) lipPadding = 4 - lipPadding;
+            }
+
+            writer.Write(0x455A5546); // string FUZE
+            writer.Write((int)0x01); // FUZE version = 0x00000001
+            writer.Write(lipSize); // lip size
+            writer.Write(fuzHeaderSize + lipSize + lipPadding); // offset to audio data
+            if (lipSize > 0)
+            {
+                writer.Write(lipData);
+                while (lipPadding-- > 0) writer.Write(0x00);
             }
         }
 

--- a/src/VGAudio.Cli/Convert.cs
+++ b/src/VGAudio.Cli/Convert.cs
@@ -60,7 +60,7 @@ namespace VGAudio.Cli
             }
 
             // check if a special FUZ header is required
-            bool isFuz = options.NxOpusHeaderType == Containers.Opus.NxOpusHeaderType.Skyrim && Path.GetExtension(fileName).ToLower() == "fuz";
+            bool isFuz = options.NxOpusHeaderType == Containers.Opus.NxOpusHeaderType.Skyrim && Path.GetExtension(fileName).ToLower() == ".fuz";
 
             using (var stream = new FileStream(fileName, FileMode.Create, FileAccess.ReadWrite))
             using (var writer = new BinaryWriter(stream, System.Text.Encoding.UTF8, true))
@@ -82,8 +82,10 @@ namespace VGAudio.Cli
                 {
                     long fileSize = stream.Position;
                     int fuzPadding = (int) (fileSize % 4);
-                    if (fuzPadding != 0) fuzPadding = 4 - fuzPadding;
-                    while (fuzPadding-- > 0) writer.Write(0x00);
+                    if (fuzPadding != 0)
+                    {
+                        while (fuzPadding++ < 4) writer.Write((byte)0x00);
+                    }
                 }
             }
         }
@@ -92,8 +94,7 @@ namespace VGAudio.Cli
         {
             const int fuzHeaderSize = 0x10;
 
-            string fileNameWithoutExtension = Path.GetDirectoryName(fileName) + Path.GetFileNameWithoutExtension(fileName);
-            string lipFileName = fileNameWithoutExtension + ".lip";
+            string lipFileName = Path.GetDirectoryName(fileName) + "\\" + Path.GetFileNameWithoutExtension(fileName) + ".lip";
 
             int lipSize = 0;
             int lipPadding = 0;
@@ -104,7 +105,10 @@ namespace VGAudio.Cli
                 lipData = File.ReadAllBytes(lipFileName);
                 lipSize = lipData.Length;
                 lipPadding = lipSize % 4;
-                if (lipPadding != 0) lipPadding = 4 - lipPadding;
+                if (lipPadding != 0)
+                {
+                    lipPadding = 4 - lipPadding;
+                }
             }
 
             writer.Write(0x455A5546); // string FUZE
@@ -114,7 +118,7 @@ namespace VGAudio.Cli
             if (lipSize > 0)
             {
                 writer.Write(lipData);
-                while (lipPadding-- > 0) writer.Write(0x00);
+                while (lipPadding-- > 0) writer.Write((byte)0x00);
             }
         }
 

--- a/src/VGAudio.Cli/CreateConfiguration.cs
+++ b/src/VGAudio.Cli/CreateConfiguration.cs
@@ -4,6 +4,7 @@ using VGAudio.Codecs.CriHca;
 using VGAudio.Containers;
 using VGAudio.Containers.Adx;
 using VGAudio.Containers.Dsp;
+using VGAudio.Containers.McAdpcm;
 using VGAudio.Containers.Hca;
 using VGAudio.Containers.Hps;
 using VGAudio.Containers.Idsp;
@@ -37,6 +38,26 @@ namespace VGAudio.Cli
         public static Configuration Dsp(Options options, Configuration inConfig = null)
         {
             DspConfiguration config = inConfig as DspConfiguration ?? new DspConfiguration();
+
+            switch (options.OutFormat)
+            {
+                case AudioFormat.Pcm16:
+                    throw new InvalidDataException("Can't use format PCM16 with DSP files");
+                case AudioFormat.Pcm8:
+                    throw new InvalidDataException("Can't use format PCM8 with DSP files");
+            }
+
+            if (options.LoopAlignment > 0)
+            {
+                config.LoopPointAlignment = options.LoopAlignment;
+            }
+
+            return config;
+        }
+
+        public static Configuration McAdpcm(Options options, Configuration inConfig = null)
+        {
+            McAdpcmConfiguration config = inConfig as McAdpcmConfiguration ?? new McAdpcmConfiguration();
 
             switch (options.OutFormat)
             {

--- a/src/VGAudio.Cli/Metadata/Containers/McAdpcm.cs
+++ b/src/VGAudio.Cli/Metadata/Containers/McAdpcm.cs
@@ -1,0 +1,41 @@
+﻿using System.IO;
+using System.Text;
+using VGAudio.Containers.McAdpcm;
+
+namespace VGAudio.Cli.Metadata.Containers
+{
+    internal class McAdpcm : MetadataReader
+    {
+        public override Common ToCommon(object structure)
+        {
+            if (!(structure is McAdpcmStructure McAdpcm)) throw new InvalidDataException("Could not parse file metadata.");
+
+            return new Common
+            {
+                SampleCount = McAdpcm.SampleCount,
+                SampleRate = McAdpcm.SampleRate,
+                ChannelCount = McAdpcm.ChannelCount,
+                Format = AudioFormat.McAdpcm,
+                Looping = McAdpcm.Looping,
+                LoopStart = McAdpcm.LoopStart,
+                LoopEnd = McAdpcm.LoopEnd
+            };
+        }
+
+        public override object ReadMetadata(Stream stream) => new McAdpcmReader().ReadMetadata(stream);
+
+        public override void PrintSpecificMetadata(object structure, StringBuilder builder)
+        {
+            if (!(structure is McAdpcmStructure McAdpcm)) throw new InvalidDataException("Could not parse file metadata.");
+
+            builder.AppendLine();
+
+            builder.AppendLine($"Nibble Count: {McAdpcm.NibbleCount}");
+            builder.AppendLine($"Start Address: 0x{McAdpcm.StartAddress:X8}");
+            builder.AppendLine($"End Address: 0x{McAdpcm.EndAddress:X8}");
+            builder.AppendLine($"Current Address: 0x{McAdpcm.CurrentAddress:X8}");
+
+            GcAdpcm.PrintAdpcmMetadata(McAdpcm.Channels, builder);
+        }
+    }
+}

--- a/src/VGAudio.Cli/Metadata/Print.cs
+++ b/src/VGAudio.Cli/Metadata/Print.cs
@@ -50,6 +50,7 @@ namespace VGAudio.Cli.Metadata
             [AudioFormat.Pcm16] = "16-bit PCM",
             [AudioFormat.Pcm8] = "8-bit PCM",
             [AudioFormat.GcAdpcm] = "GameCube \"DSP\" 4-bit ADPCM",
+            [AudioFormat.McAdpcm] = "Nintendo Switch Multi-Channel \"DSP\" 4-bit ADPCM",
             [AudioFormat.ImaAdpcm] = "IMA 4-bit ADPCM",
             [AudioFormat.CriAdx] = "CRI ADX 4-bit ADPCM",
             [AudioFormat.CriAdxFixed] = "CRI ADX 4-bit ADPCM with fixed coefficients",
@@ -62,6 +63,7 @@ namespace VGAudio.Cli.Metadata
         {
             [FileType.Wave] = new Wave(),
             [FileType.Dsp] = new Dsp(),
+            [FileType.McAdpcm] = new McAdpcm(),
             [FileType.Idsp] = new Idsp(),
             [FileType.Brstm] = new Brstm(),
             [FileType.Bcstm] = new Bcstm(),

--- a/src/VGAudio.Cli/Options.cs
+++ b/src/VGAudio.Cli/Options.cs
@@ -93,6 +93,8 @@ namespace VGAudio.Cli
         Genh,
         Atrac9,
         NxOpus,
-        OggOpus
+        OggOpus,
+        McAdpcm,
+        Fuz
     }
 }

--- a/src/VGAudio/Containers/McAdpcm/McAdpcmConfiguration.cs
+++ b/src/VGAudio/Containers/McAdpcm/McAdpcmConfiguration.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using static VGAudio.Codecs.GcAdpcm.GcAdpcmMath;
+
+namespace VGAudio.Containers.McAdpcm
+{
+    /// <summary>
+    /// Contains the options used to build the McAdpcm file.
+    /// </summary>
+    public class McAdpcmConfiguration : Configuration
+    {
+        private int _samplesPerInterleave = 0x3800;
+        /// <summary>
+        /// If <c>true</c>, recalculates the loop context when building the McAdpcm.
+        /// If <c>false</c>, reuses the loop context read from an imported McAdpcm
+        /// if available.
+        /// Default is <c>true</c>.
+        /// </summary>
+        public bool RecalculateLoopContext { get; set; } = true;
+
+        /// <summary>
+        /// The number of samples in each block when interleaving
+        /// the audio data in the audio file.
+        /// Must be divisible by 14.
+        /// Default is 14,336 (0x3800).
+        /// </summary>
+        /// <exception cref="ArgumentOutOfRangeException">Thrown if value is negative 
+        /// or not divisible by 14.</exception>
+        public int SamplesPerInterleave
+        {
+            get => _samplesPerInterleave;
+            set
+            {
+                if (value < 1)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), value,
+                        "Number of samples per interleave must be positive");
+                }
+                if (value % SamplesPerFrame != 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(value), value,
+                        "Number of samples per interleave must be divisible by 14");
+                }
+                _samplesPerInterleave = value;
+            }
+        }
+
+        /// <summary>
+        /// When building the McAdpcm file, the loop points and audio will
+        /// be adjusted so that the start loop point is a multiple of
+        /// this number. Default is 1.
+        /// </summary>
+        public int LoopPointAlignment { get; set; } = 1;
+    }
+}

--- a/src/VGAudio/Containers/McAdpcm/McAdpcmReader.cs
+++ b/src/VGAudio/Containers/McAdpcm/McAdpcmReader.cs
@@ -1,0 +1,132 @@
+﻿using System.IO;
+using System.Linq;
+using VGAudio.Formats;
+using VGAudio.Formats.GcAdpcm;
+using VGAudio.Utilities;
+using static VGAudio.Codecs.GcAdpcm.GcAdpcmMath;
+using static VGAudio.Utilities.Helpers;
+
+namespace VGAudio.Containers.McAdpcm
+{
+    public class McAdpcmReader : AudioReader<McAdpcmReader, McAdpcmStructure, McAdpcmConfiguration>
+    {
+        private static int DspHeaderCoefOffset = 0x1C;
+        private static int DspHeaderSize => 0x60;
+
+        protected override McAdpcmStructure ReadFile(Stream stream, bool readAudioData = true)
+        {
+            var structure = new McAdpcmStructure();
+
+            ReadHeader(GetBinaryReader(stream, Endianness.LittleEndian), structure);
+
+            if (readAudioData) {
+                using (BinaryReader reader = GetBinaryReader(stream, Endianness.BigEndian))
+                {
+                    reader.BaseStream.Position = structure.McadpcmHeaderSize;
+                    ReadData(reader, structure);
+                }
+            }
+
+            return structure;
+        }
+
+        protected override IAudioFormat ToAudioStream(McAdpcmStructure structure)
+        {
+            var channels = new GcAdpcmChannel[structure.ChannelCount];
+
+            for (int c = 0; c < structure.ChannelCount; c++)
+            {
+                var channelBuilder = new GcAdpcmChannelBuilder(structure.AudioData[c], structure.Channels[c].Coefs, structure.SampleCount)
+                {
+                    Gain = structure.Channels[c].Gain,
+                    StartContext = structure.Channels[c].Start
+                };
+
+                channelBuilder
+                    .WithLoop(structure.Looping, structure.LoopStart, structure.LoopEnd)
+                    .WithLoopContext(structure.LoopStart, structure.Channels[c].Loop.PredScale,
+                        structure.Channels[c].Loop.Hist1, structure.Channels[c].Loop.Hist2);
+
+                channels[c] = channelBuilder.Build();
+            }
+
+            return new GcAdpcmFormatBuilder(channels, structure.SampleRate)
+                .WithLoop(structure.Looping, structure.LoopStart, structure.LoopEnd)
+                .Build();
+        }
+
+        private static void ReadHeader(BinaryReader reader, McAdpcmStructure structure)
+        {
+            structure.ChannelCount = reader.ReadInt32();
+
+            if (structure.ChannelCount > 2)
+            {
+                throw new InvalidDataException($"McAdpcm cannot have more than 2 channels.");
+            }
+
+            structure.McadpcmHeaderSize = reader.ReadInt32();
+            structure.DspChannelDataSize = reader.ReadInt32(); // channel 0 data size
+
+            // A Stereo MCADPCM has 2 additional 32 bit fields  we don't need for computation
+            // - channel1 data offset from file start
+            // - channel1 data size (never found a case where <> than Channel0 data size)
+            reader.BaseStream.Position += (structure.ChannelCount - 1) * 0x02 * sizeof(int);
+
+            structure.SampleCount = reader.ReadInt32();
+            structure.NibbleCount = reader.ReadInt32();
+            structure.SampleRate = reader.ReadInt32();
+            structure.Looping = reader.ReadInt16() == 1;
+            structure.Format = reader.ReadInt16();
+            structure.StartAddress = reader.ReadInt32();
+            structure.EndAddress = reader.ReadInt32();
+            structure.CurrentAddress = reader.ReadInt32();
+
+            structure.Channels.Add(new GcAdpcmChannelInfo
+            {
+                Coefs = Enumerable.Range(0, 16).Select(x => reader.ReadInt16()).ToArray(),
+                Gain = reader.ReadInt16(),
+                Start = new GcAdpcmContext(reader),
+                Loop = new GcAdpcmContext(reader)
+            });
+
+            if (structure.ChannelCount == 2)
+            {
+                reader.BaseStream.Position = structure.McadpcmHeaderSize + structure.DspChannelDataSize + DspHeaderCoefOffset;
+
+                structure.Channels.Add(new GcAdpcmChannelInfo
+                {
+                    Coefs = Enumerable.Range(0, 16).Select(x => reader.ReadInt16()).ToArray(),
+                    Gain = reader.ReadInt16(),
+                    Start = new GcAdpcmContext(reader),
+                    Loop = new GcAdpcmContext(reader)
+                });
+            }
+
+            if (reader.BaseStream.Length < structure.McadpcmHeaderSize + structure.DspChannelDataSize * structure.ChannelCount)
+            {
+                throw new InvalidDataException($"File doesn't contain enough data for {structure.SampleCount} samples");
+            }
+
+            if (SampleCountToNibbleCount(structure.SampleCount) != structure.NibbleCount)
+            {
+                throw new InvalidDataException("Sample count and nibble count do not match");
+            }
+
+            if (structure.Format != 0)
+            {
+                throw new InvalidDataException($"File does not contain ADPCM audio. Specified format is {structure.Format}");
+            }
+        }
+
+        private static void ReadData(BinaryReader reader, McAdpcmStructure structure)
+        {
+            structure.AudioData = new byte[structure.ChannelCount][];
+
+            for (int i = 0; i < structure.ChannelCount; i++)
+            {
+                reader.BaseStream.Position = structure.McadpcmHeaderSize + DspHeaderSize + (structure.DspChannelDataSize) * i;
+                structure.AudioData[i] = reader.ReadBytes(structure.DspChannelDataSize - DspHeaderSize);
+            }
+        }
+    }
+}

--- a/src/VGAudio/Containers/McAdpcm/McAdpcmStructure.cs
+++ b/src/VGAudio/Containers/McAdpcm/McAdpcmStructure.cs
@@ -1,0 +1,85 @@
+﻿using System.Collections.Generic;
+using VGAudio.Codecs.GcAdpcm;
+using VGAudio.Formats.GcAdpcm;
+
+namespace VGAudio.Containers.McAdpcm
+{
+    /// <summary>
+    /// Defines the structure of a McAdpcm file.
+    /// </summary>
+    public class McAdpcmStructure
+    {
+        internal McAdpcmStructure() { }
+
+        /// <summary>
+        /// The McAdpcm header size can be 0x0C 0r 0X14 large.
+        /// </summary>
+        public int McadpcmHeaderSize { get; set; }
+
+        /// <summary>
+        /// The McAdpcm DspAdpcm channel data size.
+        /// </summary>
+        public int DspChannelDataSize { get; set; }
+
+        /// <summary>
+        /// The number of samples in the McAdpcm.
+        /// </summary>
+        public int SampleCount { get; set; }
+        /// <summary>
+        /// The number of ADPCM nibbles in the McAdpcm.
+        /// </summary>
+        public int NibbleCount { get; set; }
+        /// <summary>
+        /// The sample rate of the audio.
+        /// </summary>
+        public int SampleRate { get; set; }
+        /// <summary>
+        /// This flag is set if the McAdpcm loops.
+        /// </summary>
+        public bool Looping { get; set; }
+        /// <summary>
+        /// The format of
+        /// </summary>
+        public short Format { get; set; }
+        /// <summary>
+        /// The address, in nibbles, of the start
+        /// loop point.
+        /// </summary>
+        public int StartAddress { get; set; }
+        /// <summary>
+        /// The address, in nibbles, of the end
+        /// loop point.
+        /// </summary>
+        public int EndAddress { get; set; }
+        /// <summary>
+        /// The address, in nibbles, of the initial
+        /// playback position.
+        /// </summary>
+        public int CurrentAddress { get; set; }
+        /// <summary>
+        /// The number of channels in the McAdpcm file.
+        /// Only used in multi-channel McAdpcm files.
+        /// </summary>
+        public int ChannelCount { get; set; }
+        /// <summary>
+        /// The number of ADPCM frames in each
+        /// interleaved audio data block.
+        /// Only used in multi-channel McAdpcm files.
+        /// </summary>
+        public int FramesPerInterleave { get; set; }
+        /// <summary>
+        /// The ADPCM information for each channel.
+        /// </summary>
+        public IList<GcAdpcmChannelInfo> Channels { get; } = new List<GcAdpcmChannelInfo>();
+
+        /// <summary>
+        /// The start loop point in samples.
+        /// </summary>
+        public int LoopStart => GcAdpcmMath.NibbleToSample(StartAddress);
+        /// <summary>
+        /// The end loop point in samples.
+        /// </summary>
+        public int LoopEnd => GcAdpcmMath.NibbleToSample(EndAddress);
+        internal byte[][] AudioData { get; set; }
+    }
+}

--- a/src/VGAudio/Containers/McAdpcm/McAdpcmWriter.cs
+++ b/src/VGAudio/Containers/McAdpcm/McAdpcmWriter.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using VGAudio.Codecs.GcAdpcm;
+using VGAudio.Formats;
+using VGAudio.Formats.GcAdpcm;
+using VGAudio.Utilities;
+using static VGAudio.Codecs.GcAdpcm.GcAdpcmMath;
+using static VGAudio.Utilities.Helpers;
+
+namespace VGAudio.Containers.McAdpcm
+{
+    public class McAdpcmWriter : AudioWriter<McAdpcmWriter, McAdpcmConfiguration>
+    {
+        private static int DspHeaderSize => 0x60;
+
+        private GcAdpcmFormat Adpcm { get; set; }
+
+        protected override int FileSize => (ChannelCount == 1 ? 0x0C : 0x014) + (DspHeaderSize + AudioDataSize) * ChannelCount;
+
+        private int ChannelCount => Adpcm.ChannelCount;
+
+        private int McAdpcmHeaderSize => (ChannelCount == 1 ? 0x0C : 0x14);
+
+        private int SampleCount => (Configuration.TrimFile && Adpcm.Looping ? LoopEnd : Math.Max(Adpcm.SampleCount, LoopEnd));
+        private short Format { get; } = 0; /* 0 for ADPCM */
+
+        private int SamplesPerInterleave => Configuration.SamplesPerInterleave;
+        private int BytesPerInterleave => SampleCountToByteCount(SamplesPerInterleave);
+        private int FramesPerInterleave => BytesPerInterleave / BytesPerFrame;
+
+        private int AlignmentSamples => GetNextMultiple(Adpcm.LoopStart, Configuration.LoopPointAlignment) - Adpcm.LoopStart;
+        private int LoopStart => Adpcm.LoopStart + AlignmentSamples;
+        private int LoopEnd => Adpcm.LoopEnd + AlignmentSamples;
+
+        private int StartAddr => SampleToNibble(Adpcm.Looping ? LoopStart : 0);
+        private int EndAddr => SampleToNibble(Adpcm.Looping ? LoopEnd : SampleCount - 1);
+        private static int CurAddr => SampleToNibble(0);
+
+        protected override void SetupWriter(AudioData audio)
+        {
+            Adpcm = audio.GetFormat<GcAdpcmFormat>(new GcAdpcmParameters { Progress = Configuration.Progress });
+        }
+
+        protected override void WriteStream(Stream stream)
+        {
+            WriteMcAdpcmHeader(GetBinaryWriter(stream, Endianness.LittleEndian));
+            for (int i = 0; i < ChannelCount; i++)
+            {
+                WriteDspMcAdpcmHeader(GetBinaryWriter(stream, Endianness.LittleEndian), i);
+                WriteData(GetBinaryWriter(stream, Endianness.BigEndian), i);
+            }
+        }
+
+        private void WriteMcAdpcmHeader(BinaryWriter writer)
+        {
+            writer.BaseStream.Position = 0;
+
+            writer.Write(ChannelCount); // channel count
+            writer.Write(McAdpcmHeaderSize); // header size
+            writer.Write(DspHeaderSize + AudioDataSize); // channel 0 data size
+            if (ChannelCount == 2)
+            {
+                writer.Write(McAdpcmHeaderSize + DspHeaderSize + AudioDataSize); // chabnel 1 offset
+                writer.Write(DspHeaderSize + AudioDataSize); // channel 1 data size
+            }
+        }
+
+        private void WriteDspMcAdpcmHeader(BinaryWriter writer, int i)
+        {
+            writer.BaseStream.Position = McAdpcmHeaderSize + (DspHeaderSize + AudioDataSize) * i;
+
+            GcAdpcmChannel channel = Adpcm.Channels[i];
+            writer.Write(SampleCount);
+            writer.Write(SampleCountToNibbleCount(SampleCount));
+            writer.Write(Adpcm.SampleRate);
+            writer.Write((short)(Adpcm.Looping ? 1 : 0));
+            writer.Write(Format);
+            writer.Write(StartAddr);
+            writer.Write(EndAddr);
+            writer.Write(CurAddr);
+            writer.Write(channel.Coefs.ToByteArray());
+            writer.Write(channel.Gain);
+            channel.StartContext.Write(writer);
+            if (!Adpcm.Looping)
+            {
+                channel.LoopContext.Write(writer);
+            }
+            else
+            {
+                writer.Write(new byte[3 * sizeof(short)]);
+            }
+            writer.Write((short)(0));
+            writer.Write((short)(0));
+        }
+
+        private void WriteData(BinaryWriter writer, int i)
+        {
+            writer.BaseStream.Position = McAdpcmHeaderSize + DspHeaderSize * (i+1) + AudioDataSize * i;
+            writer.Write(Adpcm.Channels[i].GetAdpcmAudio(), 0, SampleCountToByteCount(SampleCount));
+        }
+
+        /// <summary>
+        /// Size of a single channel's ADPCM audio data with padding when written to a file
+        /// </summary>
+        private int AudioDataSize => SampleCountToByteCount(SampleCount);
+    }
+}

--- a/src/VGAudio/Containers/Opus/NxOpusReader.cs
+++ b/src/VGAudio/Containers/Opus/NxOpusReader.cs
@@ -35,6 +35,12 @@ namespace VGAudio.Containers.Opus
                     stream.Position = startPos + structure.SadfDataOffset;
                     ReadStandardHeader(GetBinaryReader(stream, Endianness.LittleEndian), structure);
                     break;
+                case NxOpusHeaderType.Skyrim:
+                    ReadSkyrimHeader(GetBinaryReader(stream, Endianness.LittleEndian), structure);
+
+                    stream.Position = startPos + structure.SkyrimHeaderSize;
+                    ReadStandardHeader(GetBinaryReader(stream, Endianness.LittleEndian), structure);
+                    break;
             }
 
             BinaryReader reader = GetBinaryReader(stream, Endianness.BigEndian);
@@ -70,6 +76,7 @@ namespace VGAudio.Containers.Opus
                 case 0x80000001: return NxOpusHeaderType.Standard;
                 case 0x5355504F: return NxOpusHeaderType.Namco; // OPUS
                 case 0x66646173: return NxOpusHeaderType.Sadf; // sadf
+                case 0xFFD58D0A: return NxOpusHeaderType.Skyrim;
                 default: throw new NotImplementedException("This Opus header is not supported");
             }
         }
@@ -93,6 +100,15 @@ namespace VGAudio.Containers.Opus
 
             structure.DataType = reader.ReadUInt32();
             structure.DataSize = reader.ReadInt32();
+        }
+
+        private static void ReadSkyrimHeader(BinaryReader reader, NxOpusStructure structure)
+        {
+            if (reader.ReadUInt32() != 0xFFD58D0A) throw new InvalidDataException();
+            structure.SkyrimSoundDurationMS = reader.ReadInt32();
+            structure.ChannelCount = reader.ReadInt32();
+            structure.SkyrimHeaderSize = reader.ReadInt32(); ; // Skyrim NX OPUS Header Size == 0x14
+            structure.SkyrimOpusDataSize = reader.ReadInt32();
         }
 
         private static void ReadNamcoHeader(BinaryReader reader, NxOpusStructure structure)
@@ -165,6 +181,7 @@ namespace VGAudio.Containers.Opus
     {
         Standard,
         Namco,
-        Sadf
+        Sadf,
+        Skyrim
     }
 }

--- a/src/VGAudio/Containers/Opus/NxOpusStructure.cs
+++ b/src/VGAudio/Containers/Opus/NxOpusStructure.cs
@@ -30,6 +30,10 @@ namespace VGAudio.Containers.Opus
         public int NamcoCoreDataLength { get; set; }
         public int SadfDataOffset { get; set; }
 
+        public int SkyrimSoundDurationMS { get; set; }
+        public int SkyrimHeaderSize { get; set; }
+        public int SkyrimOpusDataSize { get; set; }
+
         public List<OpusFrame> Frames { get; set; } = new List<OpusFrame>();
     }
 }

--- a/src/VGAudio/Containers/Opus/NxOpusWriter.cs
+++ b/src/VGAudio/Containers/Opus/NxOpusWriter.cs
@@ -115,7 +115,7 @@ namespace VGAudio.Containers.Opus
             writer.Write(duration_ms);
             writer.Write(Format.ChannelCount);
             writer.Write(SkyrimHeaderSize);
-            writer.Write(DataSize);
+            writer.Write(StandardHeaderSize + DataSize); // OPUS payload size
             writer.BaseStream.Position = startPos + SkyrimHeaderSize;
         }
 


### PR DESCRIPTION
Nintendo Switch Skyrim uses 2 container types for sound:

1. Modified GC DSP codec on a MCADPCM container
- Used in Music and FX;
- Supports up to 2 channels;
- Has a 3 x Uint32 Header for Mono and a 5 x Uint32 Header for Stereo; (channel count, header size, channel0 payload size, [channel1 offset, channel1 payload size];
- Stores audio payload in GC DSP format but GC DSP header is stored in little-endian;
- Supports the metadata command;

2. Skyrim NX OPUS codec on a FUZ container
- Used in Voices;
- Supports up to 1 channel (couldn't find any sample with more than 1);
- OPUS payload has a 5 x Uint32 Header (signature, duration ms, channel count, header size, channel0 payload size);
- Skyrim NX OPUS header is followed by the standard OPUS header;
- Skyrim NX stores both a Skyrim NX OPUS payload and a Skyrim NX LIP file (data for lips sync with sound) on a FUZ container;
- A NX FUZ container has a 4 x Uint32 header (signature, channel count = 1, lip size, Skyrim NX OPUS payload offset);

Added the FUZ logic in VGAudioCli convert.cs itself instead of creating a new container as I did for MCADPCM. Maybe not the best solution but good enough for our requirements on https://github.com/Lord-Akkrand/Skyrim-NX-Toolkit/
 