### PR TITLE
Implement KTSS format from Fire Emblem Three Houses

### DIFF
--- a/src/VGAudio.Cli/CliArguments.cs
+++ b/src/VGAudio.Cli/CliArguments.cs
@@ -353,6 +353,9 @@ namespace VGAudio.Cli
                                 case "NAMCO":
                                     nxHeaderType = NxOpusHeaderType.Namco;
                                     break;
+                                case "KTSS":
+                                    nxHeaderType = NxOpusHeaderType.Ktss;
+                                    break;
                                 default:
                                     Console.WriteLine("Invalid header type");
                                     return null;

--- a/src/VGAudio.Cli/ContainerTypes.cs
+++ b/src/VGAudio.Cli/ContainerTypes.cs
@@ -35,7 +35,7 @@ namespace VGAudio.Cli
             [FileType.Hca] = new ContainerType(new[] { "hca" }, () => new HcaReader(), () => new HcaWriter(), CreateConfiguration.Hca),
             [FileType.Genh] = new ContainerType(new[] { "genh" }, () => new GenhReader(), null, null),
             [FileType.Atrac9] = new ContainerType(new[] { "at9" }, () => new At9Reader(), null, null),
-            [FileType.NxOpus] = new ContainerType(new[] { "lopus", "nop" }, () => new NxOpusReader(), () => new NxOpusWriter(), CreateConfiguration.NxOpus),
+            [FileType.NxOpus] = new ContainerType(new[] { "lopus", "nop", "ktss" }, () => new NxOpusReader(), () => new NxOpusWriter(), CreateConfiguration.NxOpus),
             [FileType.OggOpus] = new ContainerType(new[] { "opus" }, () => new OggOpusReader(), () => new OggOpusWriter(), CreateConfiguration.NxOpus)
         };
 

--- a/src/VGAudio.Cli/ContainerTypes.cs
+++ b/src/VGAudio.Cli/ContainerTypes.cs
@@ -35,7 +35,7 @@ namespace VGAudio.Cli
             [FileType.Hca] = new ContainerType(new[] { "hca" }, () => new HcaReader(), () => new HcaWriter(), CreateConfiguration.Hca),
             [FileType.Genh] = new ContainerType(new[] { "genh" }, () => new GenhReader(), null, null),
             [FileType.Atrac9] = new ContainerType(new[] { "at9" }, () => new At9Reader(), null, null),
-            [FileType.NxOpus] = new ContainerType(new[] { "lopus", "nop", "ktss" }, () => new NxOpusReader(), () => new NxOpusWriter(), CreateConfiguration.NxOpus),
+            [FileType.NxOpus] = new ContainerType(new[] { "lopus", "nop", "ktss", "kns" }, () => new NxOpusReader(), () => new NxOpusWriter(), CreateConfiguration.NxOpus),
             [FileType.OggOpus] = new ContainerType(new[] { "opus" }, () => new OggOpusReader(), () => new OggOpusWriter(), CreateConfiguration.NxOpus)
         };
 

--- a/src/VGAudio/Containers/Opus/NxOpusReader.cs
+++ b/src/VGAudio/Containers/Opus/NxOpusReader.cs
@@ -35,6 +35,9 @@ namespace VGAudio.Containers.Opus
                     stream.Position = startPos + structure.SadfDataOffset;
                     ReadStandardHeader(GetBinaryReader(stream, Endianness.LittleEndian), structure);
                     break;
+                case NxOpusHeaderType.Ktss:
+                    ReadKtssHeader( GetBinaryReader( stream, Endianness.LittleEndian ), structure );
+                    break;
             }
 
             BinaryReader reader = GetBinaryReader(stream, Endianness.BigEndian);
@@ -70,6 +73,7 @@ namespace VGAudio.Containers.Opus
                 case 0x80000001: return NxOpusHeaderType.Standard;
                 case 0x5355504F: return NxOpusHeaderType.Namco; // OPUS
                 case 0x66646173: return NxOpusHeaderType.Sadf; // sadf
+                case 0x4B545353: return NxOpusHeaderType.Ktss; // KTSS
                 default: throw new NotImplementedException("This Opus header is not supported");
             }
         }
@@ -134,6 +138,38 @@ namespace VGAudio.Containers.Opus
             structure.LoopEnd = reader.ReadInt32();
         }
 
+        private static void ReadKtssHeader( BinaryReader reader, NxOpusStructure structure )
+        {
+            if(reader.ReadUInt32() != 0x4B545353) throw new InvalidDataException();
+            reader.ReadInt32(); // fileSize
+            reader.BaseStream.Position += 0x18; // padding
+            reader.ReadUInt16(); // Codec ID
+            reader.ReadUInt16(); // Unknown
+            reader.ReadUInt32(); // Subsection start offset
+            reader.ReadByte(); // Layer count
+            structure.ChannelCount = reader.ReadByte();
+            reader.ReadUInt16(); // Unknown
+            structure.SampleRate = reader.ReadInt32();
+            structure.SampleCount = reader.ReadInt32();
+            structure.LoopStart = reader.ReadInt32();
+            structure.LoopEnd = structure.LoopStart + reader.ReadInt32(); // Actually LoopLength
+            structure.Looping = structure.LoopStart == 0;
+            reader.ReadInt32(); // Padding. Moaaar padding. Koei Tecmo loves padding.
+            var audioSectionAddress = reader.ReadUInt32(); // Audio section address
+            reader.ReadUInt32(); // Audio section size
+            reader.ReadInt32(); // Unknown
+            reader.ReadInt32(); // Frame count
+            structure.FrameSize = reader.ReadInt16();
+            reader.ReadInt16(); // Unknown. Always 0x3C0
+            reader.ReadInt32(); // Original sample rate?
+            reader.ReadUInt16(); // Pre-skip
+            reader.ReadByte(); // Stream count
+            reader.ReadByte(); // Coupled count
+            reader.ReadBytes(structure.ChannelCount); // Channel mapping
+            reader.ReadBytes(0x70 - (int)reader.BaseStream.Position % 0x70); // Padding to next section
+            reader.BaseStream.Position = audioSectionAddress;
+        }
+
         private static void ReadData(BinaryReader reader, NxOpusStructure structure)
         {
             long startPos = reader.BaseStream.Position;
@@ -165,6 +201,7 @@ namespace VGAudio.Containers.Opus
     {
         Standard,
         Namco,
-        Sadf
+        Sadf,
+        Ktss
     }
 }

--- a/src/VGAudio/Containers/Opus/NxOpusWriter.cs
+++ b/src/VGAudio/Containers/Opus/NxOpusWriter.cs
@@ -140,7 +140,7 @@ namespace VGAudio.Containers.Opus
             writer.Write(Format.SampleRate);
             writer.Write(Format.SampleCount);
             writer.Write(Format.LoopStart);
-            writer.Write(Format.LoopStart == 0 ? 0: Format.SampleCount - Format.LoopStart);
+            writer.Write(Format.Looping ? Format.LoopEnd - Format.LoopStart : 0);
             writer.Write(0); // Padding
             writer.Write(0x70);
             writer.Write(DataSize);

--- a/src/VGAudio/Containers/Opus/NxOpusWriter.cs
+++ b/src/VGAudio/Containers/Opus/NxOpusWriter.cs
@@ -22,6 +22,8 @@ namespace VGAudio.Containers.Opus
                         return StandardFileSize;
                     case NxOpusHeaderType.Namco:
                         return NamcoHeaderSize + StandardFileSize;
+                    case NxOpusHeaderType.Ktss:
+                        return KtssHeaderSize;
                     default:
                         return 0;
                 }
@@ -30,6 +32,7 @@ namespace VGAudio.Containers.Opus
 
         private const int StandardHeaderSize = 0x28;
         private const int NamcoHeaderSize = 0x40;
+        private const int KtssHeaderSize = 0x70;
 
         private int StandardFileSize => StandardHeaderSize + DataSize;
         private int DataSize { get; set; }
@@ -60,6 +63,10 @@ namespace VGAudio.Containers.Opus
                 case NxOpusHeaderType.Namco:
                     WriteNamcoHeader(GetBinaryWriter(stream, Endianness.BigEndian));
                     WriteStandardHeader(GetBinaryWriter(stream, Endianness.LittleEndian));
+                    WriteData(GetBinaryWriter(stream, Endianness.BigEndian));
+                    break;
+                case NxOpusHeaderType.Ktss:
+                    WriteKtssHeader(GetBinaryWriter(stream, Endianness.LittleEndian));
                     WriteData(GetBinaryWriter(stream, Endianness.BigEndian));
                     break;
                 default:
@@ -116,6 +123,43 @@ namespace VGAudio.Containers.Opus
             writer.BaseStream.Position = startPos + NamcoHeaderSize;
         }
 
+        private void WriteKtssHeader(BinaryWriter writer)
+        {
+            long startPos = writer.BaseStream.Position;
+
+            writer.WriteUTF8("KTSS");
+            writer.Write(KtssHeaderSize + DataSize);
+            writer.Seek(0x20, SeekOrigin.Begin);
+            writer.Write((short)9);
+            writer.Write((byte)3);
+            writer.Write((byte)3);
+            writer.Write(0x50);
+            writer.Write((byte)1);
+            writer.Write((byte)Format.ChannelCount);
+            writer.Write((short)0);
+            writer.Write(Format.SampleRate);
+            writer.Write(Format.SampleCount);
+            writer.Write(Format.LoopStart);
+            writer.Write(Format.LoopStart == 0 ? 0: Format.SampleCount - Format.LoopStart);
+            writer.Write(0); // Padding
+            writer.Write(0x70);
+            writer.Write(DataSize);
+            writer.Write(0);
+            writer.Write(Format.Frames.Count);
+            writer.Write((short)(DataSize / Format.Frames.Count)); // Frame size
+            writer.Write((short)0x3C0); // Some constant
+            writer.Write(Format.SampleRate); // "Original" sample rate
+            writer.Write((short)Format.PreSkipCount);
+            writer.Write((byte)1);
+            writer.Write((byte)1);
+
+            // Channel mapping, Koei Tecmo doesn't seem to care about the order so we don't either
+            for (int i = 0; i < Format.ChannelCount; i++)
+                writer.Write((byte)i);
+
+            writer.BaseStream.Position = startPos + KtssHeaderSize;
+        }
+
         private void WriteData(BinaryWriter writer)
         {
             foreach (OpusFrame frame in Format.Frames)
@@ -124,6 +168,10 @@ namespace VGAudio.Containers.Opus
                 writer.Write(frame.FinalRange);
                 writer.Write(frame.Data);
             }
+
+            // KTSS need to be 0x40 aligned
+            if (Configuration.HeaderType == NxOpusHeaderType.Ktss)
+                writer.Write(new byte[0x40 - writer.BaseStream.Position % 0x40]);
         }
     }
 }


### PR DESCRIPTION
Those additions aim to add support for the KTSS (OPUS variant) format used in recent Koei Tecmo games.
I reinjected a music converted into the game with success, and the files play properly in Foobar so I'm (somewhat) confident this should be be in a good working state.

Here's proof of it working:
https://twitter.com/Raytwo_ssb/status/1187847995691278344