### PR TITLE
Change to recognize bms extension as BCWAV

### DIFF
--- a/src/VGAudio.Cli/ContainerTypes.cs
+++ b/src/VGAudio.Cli/ContainerTypes.cs
@@ -26,7 +26,7 @@ namespace VGAudio.Cli
             [FileType.Bcstm] = new ContainerType(new[] { "bcstm" }, () => new BCFstmReader(), () => new BCFstmWriter(NwTarget.Ctr), CreateConfiguration.Bxstm),
             [FileType.Bfstm] = new ContainerType(new[] { "bfstm" }, () => new BCFstmReader(), () => new BCFstmWriter(NwTarget.Cafe), CreateConfiguration.Bxstm),
             [FileType.Brwav] = new ContainerType(new[] { "brwav", "rwav" }, () => new BrwavReader(), null, CreateConfiguration.Bxstm),
-            [FileType.Bcwav] = new ContainerType(new[] { "bcwav", "cwav" }, () => new BCFstmReader(), null, CreateConfiguration.Bxstm),
+            [FileType.Bcwav] = new ContainerType(new[] { "bcwav", "cwav", "bms" }, () => new BCFstmReader(), null, CreateConfiguration.Bxstm),
             [FileType.Bfwav] = new ContainerType(new[] { "bfwav" }, () => new BCFstmReader(), null, CreateConfiguration.Bxstm),
             [FileType.Bcstp] = new ContainerType(new[] { "bcstp" }, () => new BCFstmReader(), null, CreateConfiguration.Bxstm),
             [FileType.Bfstp] = new ContainerType(new[] { "bfstp" }, () => new BCFstmReader(), null, CreateConfiguration.Bxstm),


### PR DESCRIPTION
Because in the Japanese version of "3D Classics: Kirby's Adventure"(3Dクラシックス 星のカービィ 夢の泉の物語), BCWAV was used with bms extension
![Screenshot from 2020-01-27 18-30-37](https://user-images.githubusercontent.com/28985763/73164177-bfc9ce00-4134-11ea-9364-bfd3be1c4ab9.png)

Compiled and converted successfully with Mono. | Monoで正常にコンパイル&変換できました。
OS: Ubuntu 19.10 amd64
```bash
cd VGAudio/src
nuget restore
msbuild
mono ./VGAudio.Cli/bin/Debug/net451/VGAudioCli.exe /media/nnn1590/SDCARD/kriby/bgm/BGM_00_01.bms ~/Music/converted/kirby/BGM_00_01.wav
```
Translated from Japanese to English by Google Translate. | Google 翻訳によって日本語から英語に翻訳されました。
