### PR TITLE
Update: ADX 010 Editor Template

### DIFF
--- a/docs/010-editor-templates/adx.bt
+++ b/docs/010-editor-templates/adx.bt
@@ -2,14 +2,16 @@
 //--- 010 Editor v8.0 Binary Template
 //
 //      File: adx.bt
-//   Authors: Alex Barney
-//   Version: 1.0
+//   Authors: Alex Barney, Sewer56
+//   Version: 1.0.1
 //   Purpose: Parse ADX audio files
 //  Category: Audio
 // File Mask: *.adx
 //  ID Bytes: 80 00
 //   History: 
 //   1.0   Initial Release
+//   1.0.1 Added some corrections to fields based off of reversing a CRI game.
+//         Fixed compatibility with later versions of 010 editor.
 //------------------------------------------------
 
 int DivideByRoundUp(int value, int divisor)
@@ -25,7 +27,7 @@ struct History
 
 struct Loop
 {
-    int16 LoopNum;
+    int16 Unused;
     int16 LoopType;
     int32 LoopStartSample;
     int32 LoopStartByte;
@@ -59,7 +61,7 @@ struct Header
     ubyte FrameSize;
     byte BitDepth;
     byte ChannelCount;
-    int32 SampleRate;
+    uint32 SampleRate;
     int32 SampleCount;
     int16 HighpassFreq;
     byte Version;
@@ -78,8 +80,9 @@ struct Header
         break;
 
     int16 AlignmentSamples;
-    int16 LoopCount;
-    for(i = 0; i < LoopCount; i++)
+    int16 LoopEnabled;
+
+    if (LoopEnabled == 1) 
     {
         Loop loop <open=true>;
     }
@@ -122,9 +125,9 @@ typedef struct (Header &head)
     char CopyrightMarker[6];
     for(i = 0; i < frameCount; i++)
     {
-        Frame Frames(head.FrameSize, head.ChannelCount);
+        Frame Frames();
     }    
-} Data <size=SizeData>;
+} Data;
 
 int SizeData( Data &d )
 {

--- a/docs/010-editor-templates/adx.bt
+++ b/docs/010-editor-templates/adx.bt
@@ -61,7 +61,7 @@ struct Header
     ubyte FrameSize;
     byte BitDepth;
     byte ChannelCount;
-    uint32 SampleRate;
+    int32 SampleRate;
     int32 SampleCount;
     int16 HighpassFreq;
     byte Version;


### PR DESCRIPTION
# Summary

Made a number of small changes to the ADX template.  
These are based off my personal disassembly of the Windows port of Sonic Riders, a 2006 hoverboard racing game that uses CRI. These changes are based on my disassembly of the header parsing code.

- Fixed Parse Error with Newer 010 Editor Versions
- Removed `LoopCount`. It's a simple flag that only accepts a value of 1. Any other value is ignored.
- First `short` of the Loop structure is ignored by the application. Probably reserved. Marked as such.

I made this changes while working on [ADX-ID3](https://github.com/Sewer56/ADX-ID3), a fun weekend project to add ID3 tag support to ADX.

## Regarding AINF

I noticed the template had a mention of the 'AINF' and 'CINF' structures. While I couldn't find any test files using those headers (I've tried a fair bit), I did find the code that parses it while investigating the loop stuff.

It appears the logic is the following.

```csharp
int loopOffset = version == 4 ? 32 : 20; // Start of loop header.
int ainfOffset = loopOffset + 4; // Start of loop data.
if (loopEnabled)
    ainfOffset += 20;
```

Game code specifically uses `32` and `20`. There isn't anything to compensate for the channels and the official CRI encoding tools never supported `>2 ch` for ADX as far as I'm aware.

It comes after the `Loop` structure if the enable flag is set, and in place of the loop structure if the flag is not set.  
No sample files to doublecheck, so didn't add that part in.  