### PR TITLE
Add HCA 3.0 decoding support

### DIFF
--- a/src/VGAudio/Codecs/CriHca/HcaInfo.cs
+++ b/src/VGAudio/Codecs/CriHca/HcaInfo.cs
@@ -4,6 +4,7 @@ namespace VGAudio.Codecs.CriHca
 {
     public class HcaInfo
     {
+        public int Version { get; set; }
         public int ChannelCount { get; set; }
         public int SampleRate { get; set; }
         public int SampleCount { get; set; }

--- a/src/VGAudio/Containers/Hca/HcaReader.cs
+++ b/src/VGAudio/Containers/Hca/HcaReader.cs
@@ -62,6 +62,7 @@ namespace VGAudio.Containers.Hca
             string signature = ReadChunkId(reader);
             structure.Version = reader.ReadInt16();
             structure.HeaderSize = reader.ReadInt16();
+            hca.Version = structure.Version;
             hca.HeaderSize = structure.HeaderSize;
 
             if (signature != "HCA\0")


### PR DESCRIPTION
Ported HCA3.0 decoding support from @bnnm's [vgmstream](https://github.com/vgmstream/vgmstream).

Roughly tested to work, however I can see differences in frequency spectrum, especially > 11k bands.